### PR TITLE
Add n8n compatibility settings to .env.example to address deprecation…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ N8N_PROTOCOL=https
 N8N_SSL_KEY=/ssl/server.key
 N8N_SSL_CERT=/ssl/server.crt
 
+# n8n Performance and Future Compatibility
+DB_SQLITE_POOL_SIZE=5
+N8N_RUNNERS_ENABLED=true
+N8N_BLOCK_ENV_ACCESS_IN_NODE=false
+
 # Ollama Configuration
 OLLAMA_NUM_PARALLEL=2
 OLLAMA_MAX_LOADED_MODELS=2


### PR DESCRIPTION
… warnings

- Added DB_SQLITE_POOL_SIZE=5 for SQLite connection pooling performance
- Added N8N_RUNNERS_ENABLED=true for future task runner compatibility
- Added N8N_BLOCK_ENV_ACCESS_IN_NODE=false to maintain current environment variable access behavior

These settings prevent deprecation warnings that appear when starting n8n containers and ensure compatibility with future n8n versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

