### PR TITLE
Add N8N_RUNNERS_TASK_TIMEOUT environment variable to n8n service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - N8N_EDITOR_BASE_URL=${N8N_EDITOR_BASE_URL}
       - GENERIC_TIMEZONE=${TIMEZONE}
       - N8N_SECURE_COOKIE=${N8N_SECURE_COOKIE}
+      - N8N_RUNNERS_TASK_TIMEOUT=${N8N_RUNNERS_TASK_TIMEOUT}
     volumes:
       - ./data/n8n:/home/node/.n8n
       - ./ssl:/ssl:ro


### PR DESCRIPTION
## Description

Brief description of what this PR does and why.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/DevOps change
- [ ] Security update

## Changes Made

- [ ] List specific changes made
- [ ] Include any configuration updates
- [ ] Note any new dependencies or requirements

## Testing

- [ ] I have tested these changes locally
- [ ] I have verified Docker Compose stack starts successfully
- [ ] I have tested affected services are accessible
- [ ] I have validated the configuration changes work as expected

## Security Considerations

- [ ] No sensitive information (passwords, API keys) is included in this PR
- [ ] Any new environment variables are documented in .env.example
- [ ] Security implications have been considered and documented

## Documentation

- [ ] I have updated the README.md if needed
- [ ] I have updated the .env.example if new variables were added
- [ ] I have added/updated any relevant documentation

## Deployment Notes

Any special deployment considerations or steps required:

## Screenshots (if applicable)

## Additional Context

Add any other context about the PR here.