### PR TITLE
Exclude boot partitions from disk usage monitoring in Node Exporter d…

### DIFF
--- a/monitoring/grafana/provisioning/dashboards/node-exporter.json
+++ b/monitoring/grafana/provisioning/dashboards/node-exporter.json
@@ -34,7 +34,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "(1 - (node_filesystem_avail_bytes{fstype!=\"tmpfs\",fstype!=\"squashfs\",device!~\"/dev/loop.*\"} / node_filesystem_size_bytes{fstype!=\"tmpfs\",fstype!=\"squashfs\",device!~\"/dev/loop.*\"})) * 100",
+          "expr": "(1 - (node_filesystem_avail_bytes{fstype!=\"tmpfs\",fstype!=\"squashfs\",device!~\"/dev/loop.*\",mountpoint!~\"/boot.*\"} / node_filesystem_size_bytes{fstype!=\"tmpfs\",fstype!=\"squashfs\",device!~\"/dev/loop.*\",mountpoint!~\"/boot.*\"})) * 100",
           "legendFormat": "Disk Usage % - {{mountpoint}}"
         }
       ],


### PR DESCRIPTION
…ashboard

- Added mountpoint!~"/boot.*" filter to disk usage query
- Resolves persistent 100% usage readings for /boot and /boot/efi partitions
- Boot partitions excluded as they are typically small, rarely change, and can have container permission issues
- Dashboard now focuses on operationally relevant filesystem usage metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
