### PR TITLE
Add orgId and jsonData to Prometheus datasource config

### DIFF
--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -5,6 +5,9 @@ datasources:
     type: prometheus
     access: proxy
     uid: prometheus
+    orgId: 1
     url: http://prometheus:9090
     isDefault: true
     editable: true
+    jsonData:
+      httpMethod: POST


### PR DESCRIPTION
Add explicit orgId: 1 and httpMethod: POST to datasource configuration to fix provisioning error 'data source not found'.

The error suggests Grafana's provisioning system needs these fields to properly initialize the datasource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of what this PR does and why.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/DevOps change
- [ ] Security update

## Changes Made

- [ ] List specific changes made
- [ ] Include any configuration updates
- [ ] Note any new dependencies or requirements

## Testing

- [ ] I have tested these changes locally
- [ ] I have verified Docker Compose stack starts successfully
- [ ] I have tested affected services are accessible
- [ ] I have validated the configuration changes work as expected

## Security Considerations

- [ ] No sensitive information (passwords, API keys) is included in this PR
- [ ] Any new environment variables are documented in .env.example
- [ ] Security implications have been considered and documented

## Documentation

- [ ] I have updated the README.md if needed
- [ ] I have updated the .env.example if new variables were added
- [ ] I have added/updated any relevant documentation

## Deployment Notes

Any special deployment considerations or steps required:

## Screenshots (if applicable)

## Additional Context

Add any other context about the PR here.