### PR TITLE
Fix node-exporter filesystem metrics using host network mode

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -49,8 +49,7 @@ services:
     container_name: node-exporter
     restart: unless-stopped
     pid: host
-    ports:
-      - "9100:9100"
+    network_mode: host
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -60,8 +59,6 @@ services:
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-    networks:
-      - homeserver
 
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest


### PR DESCRIPTION
Previous fix with pid: host was insufficient. Node-exporter was still reading a size-limited view of the filesystem (8.32GB instead of 98GB).

Changed to network_mode: host and removed explicit ports/networks config since host mode provides direct access to host networking. This allows node-exporter to properly read the actual filesystem size and usage.

Actual filesystem: 98GB total, 21% used
Previously reported: 8.32GB total, 0% used (incorrect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of what this PR does and why.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/DevOps change
- [ ] Security update

## Changes Made

- [ ] List specific changes made
- [ ] Include any configuration updates
- [ ] Note any new dependencies or requirements

## Testing

- [ ] I have tested these changes locally
- [ ] I have verified Docker Compose stack starts successfully
- [ ] I have tested affected services are accessible
- [ ] I have validated the configuration changes work as expected

## Security Considerations

- [ ] No sensitive information (passwords, API keys) is included in this PR
- [ ] Any new environment variables are documented in .env.example
- [ ] Security implications have been considered and documented

## Documentation

- [ ] I have updated the README.md if needed
- [ ] I have updated the .env.example if new variables were added
- [ ] I have added/updated any relevant documentation

## Deployment Notes

Any special deployment considerations or steps required:

## Screenshots (if applicable)

## Additional Context

Add any other context about the PR here.