### PR TITLE
Add WireGuard VPN container for remote access to home network

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,10 @@ OLLAMA_LOAD_TIMEOUT=600
 
 # Monitoring Configuration
 GRAFANA_PASSWORD=your_secure_grafana_password
+
+# WireGuard VPN Configuration
+WIREGUARD_SERVERURL=your-public-ip-or-domain.com
+WIREGUARD_PORT=51820
+WIREGUARD_PEERS=5
+WIREGUARD_SUBNET=10.13.13.0
+WIREGUARD_ALLOWEDIPS=0.0.0.0/0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,35 @@ services:
         echo 'Model downloads initiated. Check progress with: docker exec ollama ollama ps'
       "
 
+  wireguard:
+    image: lscr.io/linuxserver/wireguard:latest
+    container_name: wireguard
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TIMEZONE}
+      - SERVERURL=${WIREGUARD_SERVERURL}
+      - SERVERPORT=${WIREGUARD_PORT:-51820}
+      - PEERS=${WIREGUARD_PEERS:-5}
+      - PEERDNS=${SERVER_IP}
+      - INTERNAL_SUBNET=${WIREGUARD_SUBNET:-10.13.13.0}
+      - ALLOWEDIPS=${WIREGUARD_ALLOWEDIPS:-0.0.0.0/0}
+      - LOG_CONFS=${WIREGUARD_LOG_CONFS:-true}
+    ports:
+      - "${WIREGUARD_PORT:-51820}:51820/udp"
+      - "${SERVER_IP}:51821:51821/tcp"
+    volumes:
+      - ./data/wireguard:/config
+      - /lib/modules:/lib/modules:ro
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    networks:
+      - homeserver
+
 networks:
   homeserver:
     driver: bridge


### PR DESCRIPTION
- Added WireGuard service to docker-compose.yml with web UI on port 51821
- Configured for 5 peers by default with QR code generation
- Routes DNS through AdGuard for ad-blocking while connected
- Added WireGuard configuration variables to .env.example

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of what this PR does and why.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/DevOps change
- [ ] Security update

## Changes Made

- [ ] List specific changes made
- [ ] Include any configuration updates
- [ ] Note any new dependencies or requirements

## Testing

- [ ] I have tested these changes locally
- [ ] I have verified Docker Compose stack starts successfully
- [ ] I have tested affected services are accessible
- [ ] I have validated the configuration changes work as expected

## Security Considerations

- [ ] No sensitive information (passwords, API keys) is included in this PR
- [ ] Any new environment variables are documented in .env.example
- [ ] Security implications have been considered and documented

## Documentation

- [ ] I have updated the README.md if needed
- [ ] I have updated the .env.example if new variables were added
- [ ] I have added/updated any relevant documentation

## Deployment Notes

Any special deployment considerations or steps required:

## Screenshots (if applicable)

## Additional Context

Add any other context about the PR here.