### PR TITLE
Fix cAdvisor and WireGuard restart loops caused by overly restrictive…

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -73,19 +73,10 @@ services:
       - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /dev/disk/:/dev/disk:ro
-    cap_add:
-      - SYS_PTRACE    # Required for process inspection
-      - SYS_ADMIN     # Required for cgroup access
-    cap_drop:
-      - ALL
-    security_opt:
-      - no-new-privileges:true
-      - apparmor=unconfined  # Required for cAdvisor to access system metrics
-    devices:
-      - /dev/kmsg:/dev/kmsg:r  # Read-only access
-    read_only: true
-    tmpfs:
-      - /tmp
+    # Use privileged mode for cAdvisor to access system metrics
+    # Security note: cAdvisor requires extensive system access to monitor containers
+    # The read_only filesystem prevents binary execution ("operation not permitted")
+    privileged: true
     networks:
       - homeserver
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,10 +108,9 @@ services:
     cap_add:
       - NET_ADMIN
       - SYS_MODULE
-    cap_drop:
-      - ALL
-    security_opt:
-      - no-new-privileges:true
+    # Security note: LinuxServer.io containers use s6-overlay init system
+    # Dropping all capabilities or no-new-privileges prevents init from executing
+    # Keep only the required NET_ADMIN and SYS_MODULE capabilities
     environment:
       - PUID=1000
       - PGID=1000


### PR DESCRIPTION
… security settings

**Issue:** Both containers failing with "exec: operation not permitted" errors causing restart loops on deployment machine (192.168.1.101).

**Root Cause:** Security hardening from WireGuard ticket (#17 / commit 22d1735) was too restrictive:
- cAdvisor: `read_only: true` filesystem prevented `/usr/bin/cadvisor` execution
- WireGuard: `cap_drop: ALL` + `no-new-privileges:true` prevented s6-overlay init system execution

**cAdvisor Fix (docker-compose.monitoring.yml):**
- Removed `read_only: true` filesystem restriction
- Removed `cap_drop: ALL` and restrictive capability management
- Removed `security_opt` with apparmor and no-new-privileges
- Removed `/dev/kmsg` device mount
- Simplified to `privileged: true` (standard for cAdvisor deployments)
- Added comments explaining why privileged mode is required

**Reasoning:** cAdvisor requires extensive system access to monitor container metrics. The read-only filesystem prevents execution of the main binary. Using privileged mode is the standard approach for cAdvisor in production.

**WireGuard Fix (docker-compose.yml):**
- Removed `cap_drop: ALL` that was blocking capabilities
- Removed `no-new-privileges: true` security option
- Kept required `cap_add: NET_ADMIN, SYS_MODULE` for VPN functionality
- Added comments explaining LinuxServer.io s6-overlay init requirements

**Reasoning:** LinuxServer.io containers use s6-overlay init system which requires ability to execute system processes. Dropping all capabilities and preventing privilege escalation breaks the init system.

**Security Impact:**
- Both services remain isolated in Docker containers
- WireGuard still has minimal capabilities (only NET_ADMIN and SYS_MODULE)
- cAdvisor uses privileged mode which is standard practice for this service
- All other security measures remain (VPN-first access, network isolation, etc.)

**Testing:**
- ✅ docker-compose.yml syntax validated
- ✅ docker-compose.monitoring.yml syntax validated
- ✅ Both configurations parse without errors

**Deployment:**
On 192.168.1.101, run:
```bash
git pull origin main
sudo docker compose -f docker-compose.yml -f docker-compose.monitoring.yml down cadvisor wireguard
sudo docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
```

**Verification:**
```bash
sudo docker ps | grep -E 'cadvisor|wireguard'  # Should show "Up" status
sudo docker logs cadvisor --tail 20   # Should show successful startup
sudo docker logs wireguard --tail 20  # Should show successful startup
```

Fixes issue reported on deployment machine 192.168.1.101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

