### PR TITLE
fix(bede): inject current date into scheduled task prompts

### DIFF
--- a/bede/scheduler.py
+++ b/bede/scheduler.py
@@ -118,6 +118,8 @@ async def _run_task(task: dict):
     tz = ZoneInfo(TIMEZONE)
     now = datetime.now(tz)
     now_str = now.strftime("%H:%M")
+    now_date_str = now.strftime("%A, %d %B %Y")
+    prompt = f"Today is {now_date_str}.\n\n{prompt}"
 
     # Calculate next run time
     next_str = ""


### PR DESCRIPTION
## Summary

- Prepends today's date (e.g. `Today is Friday, 11 April 2025.`) to every scheduled task prompt before passing it to Claude
- Fixes morning digest (and all other scheduled tasks) showing wrong day/date in their output, because Claude had no date context and was hallucinating it

## Test plan

- [ ] Deploy to server and verify next morning digest shows the correct day and date
- [ ] Confirm other scheduled tasks also reflect the correct date when relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)