### PR TITLE
feat(health): add Apple Health ingestion stack (hae-server + hae-influxdb)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -221,21 +221,16 @@ TRAFFIC_ROUTE_2_SCHEDULE="Mon-Fri 17:00-19:00"
 # Health Auto Export Server
 # Receives health data POSTs from the Health Auto Export iOS app.
 # Access: https://hae.DOMAIN
+# Image:  irvinlim/apple-health-ingester (pre-built, no build step required)
+# Data stored as JSON files in ./data/hae-server/
 #
 # iPhone setup: In Health Auto Export, set destination to:
-#   URL:    https://hae.DOMAIN/api/data
-#   Header: api-key: HAE_WRITE_TOKEN
+#   URL:    https://hae.DOMAIN/api/healthautoexport/v1/localfile/ingest
+#   Auth:   Bearer token: HAE_WRITE_TOKEN
 # -----------------------------------------------------------------------------
-HAE_MONGO_USERNAME=admin
-HAE_MONGO_PASSWORD=your_secure_hae_mongo_password
 
-# Token the iOS app sends in the api-key header when POSTing data.
-# MUST start with "sk-" (enforced by hae-server auth middleware).
-HAE_WRITE_TOKEN=sk-your-secure-hae-write-token
-
-# Token Bede uses in the api-key header when querying the read API.
-# MUST start with "sk-" (enforced by hae-server auth middleware).
-HAE_READ_TOKEN=sk-your-secure-hae-read-token
+# Bearer token the iOS app sends when POSTing data (Authorization: Bearer <token>).
+HAE_WRITE_TOKEN=your-secure-hae-write-token
 
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -229,11 +229,13 @@ TRAFFIC_ROUTE_2_SCHEDULE="Mon-Fri 17:00-19:00"
 HAE_MONGO_USERNAME=admin
 HAE_MONGO_PASSWORD=your_secure_hae_mongo_password
 
-# Token the iOS app sends in the api-key header when POSTing data
-HAE_WRITE_TOKEN=your_secure_hae_write_token
+# Token the iOS app sends in the api-key header when POSTing data.
+# MUST start with "sk-" (enforced by hae-server auth middleware).
+HAE_WRITE_TOKEN=sk-your-secure-hae-write-token
 
-# Token Bede uses in the Authorization header when querying the read API
-HAE_READ_TOKEN=your_secure_hae_read_token
+# Token Bede uses in the api-key header when querying the read API.
+# MUST start with "sk-" (enforced by hae-server auth middleware).
+HAE_READ_TOKEN=sk-your-secure-hae-read-token
 
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -222,15 +222,23 @@ TRAFFIC_ROUTE_2_SCHEDULE="Mon-Fri 17:00-19:00"
 # Receives health data POSTs from the Health Auto Export iOS app.
 # Access: https://hae.DOMAIN
 # Image:  irvinlim/apple-health-ingester (pre-built, no build step required)
-# Data stored as JSON files in ./data/hae-server/
+# Data stored in InfluxDB (./data/hae-influxdb/)
 #
 # iPhone setup: In Health Auto Export, set destination to:
-#   URL:    https://hae.DOMAIN/api/healthautoexport/v1/localfile/ingest
+#   URL:    https://hae.DOMAIN/api/healthautoexport/v1/influxdb/ingest
 #   Auth:   Bearer token: HAE_WRITE_TOKEN
 # -----------------------------------------------------------------------------
 
 # Bearer token the iOS app sends when POSTing data (Authorization: Bearer <token>).
 HAE_WRITE_TOKEN=your-secure-hae-write-token
+
+# InfluxDB credentials and configuration.
+HAE_INFLUXDB_USERNAME=admin
+HAE_INFLUXDB_PASSWORD=your-secure-influxdb-password
+HAE_INFLUXDB_TOKEN=your-secure-influxdb-admin-token
+HAE_INFLUXDB_ORG=health
+HAE_INFLUXDB_METRICS_BUCKET=metrics
+HAE_INFLUXDB_WORKOUTS_BUCKET=workouts
 
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -212,6 +212,31 @@ TRAFFIC_ROUTE_2_SCHEDULE="Mon-Fri 17:00-19:00"
 # Add more routes as needed (ROUTE_3, ROUTE_4, etc.)
 
 # =============================================================================
+# HEALTH SERVICES  (docker-compose.health.yml)
+# Apple Health data ingestion via Health Auto Export iOS app.
+# hae-server receives POSTs from the app and exposes a read API for Bede.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Health Auto Export Server
+# Receives health data POSTs from the Health Auto Export iOS app.
+# Access: https://hae.DOMAIN
+#
+# iPhone setup: In Health Auto Export, set destination to:
+#   URL:    https://hae.DOMAIN/api/data
+#   Header: api-key: HAE_WRITE_TOKEN
+# -----------------------------------------------------------------------------
+HAE_MONGO_USERNAME=admin
+HAE_MONGO_PASSWORD=your_secure_hae_mongo_password
+
+# Token the iOS app sends in the api-key header when POSTing data
+HAE_WRITE_TOKEN=your_secure_hae_write_token
+
+# Token Bede uses in the Authorization header when querying the read API
+HAE_READ_TOKEN=your_secure_hae_read_token
+
+
+# =============================================================================
 # BEDE PERSONAL ASSISTANT (docker-compose.ai.yml)
 # Telegram bot wrapping Claude Code CLI for personal assistant use.
 # =============================================================================

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hae-server"]
+	path = hae-server
+	url = https://github.com/HealthyApps/health-auto-export-server

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "hae-server"]
-	path = hae-server
-	url = https://github.com/HealthyApps/health-auto-export-server

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,6 @@ build: validate
 # Build only custom services (faster rebuild during development)
 build-custom: validate
 	@echo "Building custom services from source..."
-	@git submodule update --init hae-server
 	@$(COMPOSE) build homepage-api hae-server --progress=plain
 	@echo "✓ Custom services built"
 
@@ -152,7 +151,6 @@ setup: env-check validate wireguard-check
 	@$(COMPOSE) pull --ignore-pull-failures
 	@echo ""
 	@echo "Step 5/8: Building custom services from source..."
-	@git submodule update --init hae-server
 	@$(COMPOSE) build homepage-api hae-server --progress=plain
 	@echo ""
 	@echo "Step 6/8: Starting services (Docker Compose will create networks)..."
@@ -294,7 +292,6 @@ update: env-check validate wireguard-check
 	@$(COMPOSE) pull --ignore-pull-failures
 	@echo ""
 	@echo "Step 2/3: Building custom services from source..."
-	@git submodule update --init hae-server
 	@$(COMPOSE) build homepage-api hae-server --progress=plain
 	@echo ""
 	@echo "Step 3/3: Restarting services with new images..."
@@ -376,13 +373,11 @@ COMPOSE_HEALTH := docker compose -f docker-compose.health.yml
 
 hae-build: env-check
 	@echo "Building hae-server image..."
-	@git submodule update --init hae-server
 	@$(COMPOSE_HEALTH) build --progress=plain
 	@echo "✓ hae-server image built"
 
 hae-start: env-check
 	@echo "Starting health services..."
-	@git submodule update --init hae-server
 	@$(COMPOSE_HEALTH) up -d
 	@echo "✓ Health services started"
 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@
 # Simplifies deployment and maintenance operations
 
 .PHONY: help setup update start stop restart logs build build-custom pull status clean purge validate env-check
-.PHONY: logs-n8n logs-homepage logs-bede
+.PHONY: logs-n8n logs-homepage logs-bede logs-hae
 .PHONY: setup-certs test-domain-access
 .PHONY: wireguard-status wireguard-install wireguard-setup wireguard-routing wireguard-test wireguard-peers wireguard-check
 .PHONY: ssl-setup ssl-renew-test
 .PHONY: ddns-setup ddns-update ddns-status
 .PHONY: bede-start bede-stop bede-restart bede-build bede-status
+.PHONY: hae-start hae-stop hae-restart hae-build hae-status
 
 # Compose file flags
 # Services are organized into logical groups:
@@ -16,6 +17,7 @@
 # - docker-compose.monitoring.yml: Monitoring stack (Prometheus, Grafana, Alertmanager, exporters)  
 # - docker-compose.dashboard.yml: Dashboard (Homepage, Homepage API)
 # - docker-compose.ai.yml: AI services (Bede, workspace-mcp)
+# - docker-compose.health.yml: Health services (hae-server, hae-mongo)
 #
 # NOTE: WireGuard is now a system service, not Docker service
 # Install with: sudo ./scripts/wireguard/install-wireguard.sh
@@ -24,7 +26,7 @@
 # COMPOSE_CORE: Core + Network + Monitoring (used for operations that shouldn't restart dashboard or AI)
 # COMPOSE: All services including dashboard and AI (default for most operations)
 COMPOSE_CORE := docker compose -f docker-compose.yml -f docker-compose.network.yml -f docker-compose.monitoring.yml
-COMPOSE := docker compose -f docker-compose.yml -f docker-compose.network.yml -f docker-compose.monitoring.yml -f docker-compose.dashboard.yml -f docker-compose.ai.yml
+COMPOSE := docker compose -f docker-compose.yml -f docker-compose.network.yml -f docker-compose.monitoring.yml -f docker-compose.dashboard.yml -f docker-compose.ai.yml -f docker-compose.health.yml
 
 # Default target - show help
 help:
@@ -56,6 +58,14 @@ help:
 	@echo "  make logs-n8n           - Show n8n logs only"
 	@echo "  make logs-homepage      - Show Homepage logs only"
 	@echo "  make logs-bede          - Show Bede logs only"
+	@echo "  make logs-hae           - Show hae-server and hae-mongo logs only"
+	@echo ""
+	@echo "Health Auto Export (Individual Service Management):"
+	@echo "  make hae-build          - Build hae-server Docker image"
+	@echo "  make hae-start          - Start health services only"
+	@echo "  make hae-stop           - Stop health services only"
+	@echo "  make hae-restart        - Restart health services only"
+	@echo "  make hae-status         - Show health container status"
 	@echo ""
 	@echo "Bede AI Assistant (Individual Service Management):"
 	@echo "  make bede-build         - Build Bede Docker image"
@@ -115,7 +125,8 @@ build: validate
 # Build only custom services (faster rebuild during development)
 build-custom: validate
 	@echo "Building custom services from source..."
-	@$(COMPOSE) build homepage-api --progress=plain
+	@git submodule update --init hae-server
+	@$(COMPOSE) build homepage-api hae-server --progress=plain
 	@echo "✓ Custom services built"
 
 # Pull latest images for services using pre-built images
@@ -141,7 +152,8 @@ setup: env-check validate wireguard-check
 	@$(COMPOSE) pull --ignore-pull-failures
 	@echo ""
 	@echo "Step 5/8: Building custom services from source..."
-	@$(COMPOSE) build homepage-api --progress=plain
+	@git submodule update --init hae-server
+	@$(COMPOSE) build homepage-api hae-server --progress=plain
 	@echo ""
 	@echo "Step 6/8: Starting services (Docker Compose will create networks)..."
 	@$(COMPOSE) up -d
@@ -282,7 +294,8 @@ update: env-check validate wireguard-check
 	@$(COMPOSE) pull --ignore-pull-failures
 	@echo ""
 	@echo "Step 2/3: Building custom services from source..."
-	@$(COMPOSE) build homepage-api --progress=plain
+	@git submodule update --init hae-server
+	@$(COMPOSE) build homepage-api hae-server --progress=plain
 	@echo ""
 	@echo "Step 3/3: Restarting services with new images..."
 	@$(COMPOSE) up -d
@@ -328,6 +341,9 @@ logs-homepage:
 logs-bede:
 	@$(COMPOSE) logs -f bede
 
+logs-hae:
+	@$(COMPOSE) logs -f hae-server hae-mongo
+
 # Bede AI Assistant (docker-compose.ai.yml)
 COMPOSE_AI := docker compose -f docker-compose.ai.yml
 
@@ -354,6 +370,34 @@ bede-restart: env-check
 
 bede-status:
 	@$(COMPOSE_AI) ps
+
+# Health Auto Export services (docker-compose.health.yml)
+COMPOSE_HEALTH := docker compose -f docker-compose.health.yml
+
+hae-build: env-check
+	@echo "Building hae-server image..."
+	@git submodule update --init hae-server
+	@$(COMPOSE_HEALTH) build --progress=plain
+	@echo "✓ hae-server image built"
+
+hae-start: env-check
+	@echo "Starting health services..."
+	@git submodule update --init hae-server
+	@$(COMPOSE_HEALTH) up -d
+	@echo "✓ Health services started"
+
+hae-stop:
+	@echo "Stopping health services..."
+	@$(COMPOSE_HEALTH) down
+	@echo "✓ Health services stopped"
+
+hae-restart: env-check
+	@echo "Restarting health services..."
+	@$(COMPOSE_HEALTH) up -d
+	@echo "✓ Health services restarted"
+
+hae-status:
+	@$(COMPOSE_HEALTH) ps
 
 # Clean up all services (preserves ./data/)
 clean:

--- a/bede/CLAUDE.md.example
+++ b/bede/CLAUDE.md.example
@@ -20,8 +20,9 @@ You are Bede, a personal AI assistant.
 
 - Answer questions and have conversations
 - Help draft messages, emails, and documents
-- Query and update the Obsidian vault at `/vault/` (Phase 2)
-- Summarise calendar events and emails via MCP tools (Phase 2)
+- Query and update the Obsidian vault at `/vault/`
+- Summarise calendar events and emails via Google Workspace MCP tools
+- Query Apple Health data from InfluxDB
 
 ## What You Must Not Do
 
@@ -35,3 +36,22 @@ You are Bede, a personal AI assistant.
 - Confirm before any write operation that wasn't explicitly requested
 - If uncertain about intent, ask one clarifying question rather than guessing
 - For scheduled briefings, include a date/time header so context is clear
+
+## Health Data
+
+Apple Health metrics are stored in InfluxDB, populated by the Health Auto Export iOS app.
+
+**Connection:**
+- URL: `http://hae-influxdb:8086`
+- Auth token: `HAE_INFLUXDB_TOKEN` environment variable
+- Org: `HAE_INFLUXDB_ORG` environment variable
+- Metrics bucket: `HAE_INFLUXDB_METRICS_BUCKET` environment variable
+- Workouts bucket: `HAE_INFLUXDB_WORKOUTS_BUCKET` environment variable
+
+**Querying:** Use Flux query language via the InfluxDB HTTP API (`POST /api/v2/query`).
+
+**Key metrics available:** step_count, sleep_analysis, heart_rate_variability, resting_heart_rate, active_energy, apple_exercise_time, apple_stand_time, apple_move_time, mindful_minutes, state_of_mind, and workouts (in the workouts bucket).
+
+## Google Account
+
+- Email: your-google-account@gmail.com

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -23,6 +23,7 @@ services:
       - workspace-mcp
     networks:
       - default
+      - homeserver
     # No Traefik labels — bede communicates outbound via Telegram only
 
   workspace-mcp:

--- a/docker-compose.health.yml
+++ b/docker-compose.health.yml
@@ -1,26 +1,46 @@
 ---
 # Health Services
 # This file contains Apple Health data ingestion and storage services.
-# - hae-server: REST API server that receives Health Auto Export POSTs (irvinlim/apple-health-ingester)
-#               Stores data as JSON files in ./data/hae-server/
+# - hae-influxdb: InfluxDB time-series database for health metrics
+# - hae-server:   REST API server that receives Health Auto Export POSTs (irvinlim/apple-health-ingester)
 #
 # iPhone setup: In Health Auto Export app, set destination to:
-#   URL:    https://hae.DOMAIN/api/healthautoexport/v1/localfile/ingest
+#   URL:    https://hae.DOMAIN/api/healthautoexport/v1/influxdb/ingest
 #   Auth:   Bearer token: HAE_WRITE_TOKEN
 
 services:
+  hae-influxdb:
+    image: influxdb:2
+    container_name: hae-influxdb
+    restart: unless-stopped
+    volumes:
+      - ./data/hae-influxdb:/var/lib/influxdb2
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: ${HAE_INFLUXDB_USERNAME}
+      DOCKER_INFLUXDB_INIT_PASSWORD: ${HAE_INFLUXDB_PASSWORD}
+      DOCKER_INFLUXDB_INIT_ORG: ${HAE_INFLUXDB_ORG}
+      DOCKER_INFLUXDB_INIT_BUCKET: ${HAE_INFLUXDB_METRICS_BUCKET}
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${HAE_INFLUXDB_TOKEN}
+    networks:
+      - homeserver
+
   hae-server:
     image: irvinlim/apple-health-ingester:v0.5.0
     container_name: hae-server
     restart: unless-stopped
     command:
-      - --backend.localfile
-      - --localfile.metricsPath=/data/metrics
+      - --backend.influxdb
+      - --influxdb.serverURL=http://hae-influxdb:8086
+      - --influxdb.authToken=${HAE_INFLUXDB_TOKEN}
+      - --influxdb.orgName=${HAE_INFLUXDB_ORG}
+      - --influxdb.metricsBucketName=${HAE_INFLUXDB_METRICS_BUCKET}
+      - --influxdb.workoutsBucketName=${HAE_INFLUXDB_WORKOUTS_BUCKET}
       - --http.authToken=${HAE_WRITE_TOKEN}
     expose:
       - 8080
-    volumes:
-      - ./data/hae-server:/data
+    depends_on:
+      - hae-influxdb
     networks:
       - homeserver
     labels:

--- a/docker-compose.health.yml
+++ b/docker-compose.health.yml
@@ -1,46 +1,26 @@
 ---
 # Health Services
 # This file contains Apple Health data ingestion and storage services.
-# - hae-mongo: MongoDB database for Health Auto Export data
-# - hae-server: REST API server that receives Health Auto Export POSTs and serves read API
+# - hae-server: REST API server that receives Health Auto Export POSTs (irvinlim/apple-health-ingester)
+#               Stores data as JSON files in ./data/hae-server/
 #
 # iPhone setup: In Health Auto Export app, set destination to:
-#   URL:    https://hae.DOMAIN/api/data
-#   Header: api-key: HAE_WRITE_TOKEN
+#   URL:    https://hae.DOMAIN/api/healthautoexport/v1/localfile/ingest
+#   Auth:   Bearer token: HAE_WRITE_TOKEN
 
 services:
-  hae-mongo:
-    image: mongo:7
-    container_name: hae-mongo
-    restart: unless-stopped
-    volumes:
-      - ./data/hae-mongo:/data/db
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: ${HAE_MONGO_USERNAME}
-      MONGO_INITDB_ROOT_PASSWORD: ${HAE_MONGO_PASSWORD}
-      MONGO_INITDB_DATABASE: health-auto-export
-    networks:
-      - homeserver
-
   hae-server:
-    build:
-      context: ./hae-server/server
-      dockerfile: Dockerfile
+    image: irvinlim/apple-health-ingester:v0.5.0
     container_name: hae-server
     restart: unless-stopped
+    command:
+      - --backend.localfile
+      - --localfile.metricsPath=/data/metrics
+      - --http.authToken=${HAE_WRITE_TOKEN}
     expose:
-      - 3001
-    environment:
-      - NODE_ENV=production
-      - MONGO_HOST=hae-mongo
-      - MONGO_PORT=27017
-      - MONGO_DB=health-auto-export
-      - MONGO_USERNAME=${HAE_MONGO_USERNAME}
-      - MONGO_PASSWORD=${HAE_MONGO_PASSWORD}
-      - READ_TOKEN=${HAE_READ_TOKEN}
-      - WRITE_TOKEN=${HAE_WRITE_TOKEN}
-    depends_on:
-      - hae-mongo
+      - 8080
+    volumes:
+      - ./data/hae-server:/data
     networks:
       - homeserver
     labels:
@@ -48,7 +28,7 @@ services:
       - "traefik.http.routers.hae-server.rule=Host(`hae.${DOMAIN}`)"
       - "traefik.http.routers.hae-server.entrypoints=websecure"
       - "traefik.http.routers.hae-server.tls=true"
-      - "traefik.http.services.hae-server.loadbalancer.server.port=3001"
+      - "traefik.http.services.hae-server.loadbalancer.server.port=8080"
       # Security: VPN/Local access only — health data should never be public
       - "traefik.http.routers.hae-server.middlewares=admin-secure@docker"
 

--- a/docker-compose.health.yml
+++ b/docker-compose.health.yml
@@ -1,0 +1,58 @@
+---
+# Health Services
+# This file contains Apple Health data ingestion and storage services.
+# - hae-mongo: MongoDB database for Health Auto Export data
+# - hae-server: REST API server that receives Health Auto Export POSTs and serves read API
+#
+# iPhone setup: In Health Auto Export app, set destination to:
+#   URL:    https://hae.DOMAIN/api/data
+#   Header: api-key: HAE_WRITE_TOKEN
+
+services:
+  hae-mongo:
+    image: mongo:7
+    container_name: hae-mongo
+    restart: unless-stopped
+    volumes:
+      - ./data/hae-mongo:/data/db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${HAE_MONGO_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${HAE_MONGO_PASSWORD}
+      MONGO_INITDB_DATABASE: health-auto-export
+    networks:
+      - homeserver
+
+  hae-server:
+    build:
+      context: ./hae-server/server
+      dockerfile: Dockerfile
+    container_name: hae-server
+    restart: unless-stopped
+    expose:
+      - 3001
+    environment:
+      - NODE_ENV=production
+      - MONGO_HOST=hae-mongo
+      - MONGO_PORT=27017
+      - MONGO_DB=health-auto-export
+      - MONGO_USERNAME=${HAE_MONGO_USERNAME}
+      - MONGO_PASSWORD=${HAE_MONGO_PASSWORD}
+      - READ_TOKEN=${HAE_READ_TOKEN}
+      - WRITE_TOKEN=${HAE_WRITE_TOKEN}
+    depends_on:
+      - hae-mongo
+    networks:
+      - homeserver
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.hae-server.rule=Host(`hae.${DOMAIN}`)"
+      - "traefik.http.routers.hae-server.entrypoints=websecure"
+      - "traefik.http.routers.hae-server.tls=true"
+      - "traefik.http.services.hae-server.loadbalancer.server.port=3001"
+      # Security: VPN/Local access only — health data should never be public
+      - "traefik.http.routers.hae-server.middlewares=admin-secure@docker"
+
+networks:
+  homeserver:
+    external: true
+    name: home-server-stack_homeserver

--- a/docker-compose.health.yml
+++ b/docker-compose.health.yml
@@ -49,8 +49,8 @@ services:
       - "traefik.http.routers.hae-server.entrypoints=websecure"
       - "traefik.http.routers.hae-server.tls=true"
       - "traefik.http.services.hae-server.loadbalancer.server.port=8080"
-      # Security: webhook-secure (public access, bearer token auth handled by ingester)
-      - "traefik.http.routers.hae-server.middlewares=webhook-secure@docker"
+      # Security: VPN/local access only + bearer token auth handled by ingester
+      - "traefik.http.routers.hae-server.middlewares=admin-secure@docker"
 
 networks:
   homeserver:

--- a/docker-compose.health.yml
+++ b/docker-compose.health.yml
@@ -49,8 +49,8 @@ services:
       - "traefik.http.routers.hae-server.entrypoints=websecure"
       - "traefik.http.routers.hae-server.tls=true"
       - "traefik.http.services.hae-server.loadbalancer.server.port=8080"
-      # Security: VPN/Local access only — health data should never be public
-      - "traefik.http.routers.hae-server.middlewares=admin-secure@docker"
+      # Security: webhook-secure (public access, bearer token auth handled by ingester)
+      - "traefik.http.routers.hae-server.middlewares=webhook-secure@docker"
 
 networks:
   homeserver:

--- a/docker-compose.health.yml
+++ b/docker-compose.health.yml
@@ -24,6 +24,13 @@ services:
       DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: ${HAE_INFLUXDB_TOKEN}
     networks:
       - homeserver
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.hae-influxdb.rule=Host(`influxdb.${DOMAIN}`)"
+      - "traefik.http.routers.hae-influxdb.entrypoints=websecure"
+      - "traefik.http.routers.hae-influxdb.tls=true"
+      - "traefik.http.services.hae-influxdb.loadbalancer.server.port=8086"
+      - "traefik.http.routers.hae-influxdb.middlewares=admin-secure@docker"
 
   hae-server:
     image: irvinlim/apple-health-ingester:v0.5.0

--- a/docker-compose.network.yml
+++ b/docker-compose.network.yml
@@ -42,6 +42,9 @@ services:
       # TLS
       - "--entrypoints.websecure.http.tls=true"
 
+      # Increase response timeout to handle large health data history exports
+      - "--entrypoints.websecure.transport.respondingTimeouts.readTimeout=300s"
+
       # Ping endpoint for health checks
       - "--ping=true"
 

--- a/docs/health-auto-export.md
+++ b/docs/health-auto-export.md
@@ -1,0 +1,190 @@
+# Health Auto Export Setup
+
+This document covers setting up `hae-server` and `hae-mongo` to receive Apple Health
+data from the [Health Auto Export](https://apple.co/3iqbU2d) iOS app, and how to
+configure the iPhone automations to push data to your server.
+
+## Overview
+
+The health stack (`docker-compose.health.yml`) consists of two services:
+
+- **hae-mongo** — MongoDB 7 database that stores all incoming health data
+- **hae-server** — Node.js REST API that receives POSTs from the iOS app (`/api/data`)
+  and exposes read endpoints (`/api/metrics/:name`, `/api/workouts`) for Bede or other
+  consumers
+
+The upstream project is [HealthyApps/health-auto-export-server](https://github.com/HealthyApps/health-auto-export-server),
+vendored here as a git submodule at `./hae-server`.
+
+---
+
+## Server Setup
+
+### 1. Generate API tokens
+
+Tokens must start with `sk-`. Generate two (one for writing, one for reading):
+
+```bash
+echo "sk-$(openssl rand -hex 32)"   # run twice
+```
+
+### 2. Add environment variables to `.env`
+
+```bash
+HAE_MONGO_USERNAME=admin
+HAE_MONGO_PASSWORD=your_secure_mongo_password
+
+# Token the iOS app sends when POSTing data
+HAE_WRITE_TOKEN=sk-your-write-token
+
+# Token Bede (or Grafana) uses when reading data
+HAE_READ_TOKEN=sk-your-read-token
+```
+
+Both token values **must start with `sk-`** — the server's auth middleware enforces
+this and will return 401 for any token without the prefix.
+
+### 3. Build and start
+
+The `hae-server` image is built from source (git submodule). Initialise the submodule
+if you haven't already:
+
+```bash
+git submodule update --init hae-server
+make hae-build
+make hae-start
+```
+
+Or it's included in the full stack:
+
+```bash
+make build   # builds all custom images including hae-server
+make start   # starts everything
+```
+
+### 4. Verify
+
+```bash
+make hae-status     # both containers should show Up
+make logs-hae       # hae-server should print "Connected successfully to health-auto-export"
+```
+
+Test the write endpoint from the server:
+
+```bash
+docker exec hae-server wget -q -O- \
+  --post-data='{"data":[]}' \
+  --header='Content-Type: application/json' \
+  --header='api-key: sk-your-write-token' \
+  http://localhost:3001/api/data
+# Expected: {"metrics":{"success":true,...},"workouts":{"success":true,...}}
+```
+
+Test a read endpoint:
+
+```bash
+docker exec hae-server wget -q -O- \
+  --header='api-key: sk-your-read-token' \
+  'http://localhost:3001/api/metrics/step_count'
+# Expected: [] (empty until data has been synced from iPhone)
+```
+
+---
+
+## iPhone Setup
+
+Install **Health Auto Export** from the App Store. Under the **Automations** tab,
+create the following automations. Each taps **Update** to save and **Manual Export**
+to trigger a first sync.
+
+### Automation 1 — Health Metrics
+
+| Setting | Value |
+|---|---|
+| Automation Type | REST API |
+| URL | `https://hae.YOUR_DOMAIN/api/data` |
+| Header key | `api-key` |
+| Header value | `HAE_WRITE_TOKEN` value from `.env` |
+| Data Type | Health Metrics |
+| Export Format | JSON |
+| Aggregate Data | On |
+| Aggregate Interval | Day |
+| Batch Requests | On |
+| Date Range | Since Last Sync |
+
+Recommended metrics to enable (maps to what Bede uses in the journal):
+
+| Metric name in app | Enum value (read API) |
+|---|---|
+| Sleep Analysis | `sleep_analysis` |
+| Step Count | `step_count` |
+| Heart Rate Variability | `heart_rate_variability` |
+| Resting Heart Rate | `resting_heart_rate` |
+| Active Energy | `active_energy` |
+| Apple Exercise Time | `apple_exercise_time` |
+| Apple Stand Time | `apple_stand_time` |
+| Apple Move Time | `apple_move_time` |
+| Mindful Minutes | `mindful_minutes` |
+| State of Mind | `state_of_mind` |
+
+You can enable additional metrics freely — they are stored in MongoDB and can be
+queried later without any server changes.
+
+### Automation 2 — Workouts
+
+Same settings as above, but **Data Type = Workouts**. This captures gym sessions,
+runs, and any other recorded workout activity.
+
+### Automation 3 — Medications *(optional)*
+
+Same settings, Data Type = Health Metrics, metrics = Medications only. Only needed
+if you log medications in the Health app and want Bede to include them in the journal.
+
+### Manual first sync
+
+After saving each automation, tap **Manual Export**, set the date range to
+**Last 7 Days**, and trigger it. This pre-populates the database immediately rather
+than waiting for the next scheduled sync.
+
+### Sync frequency note
+
+iOS only allows the app to access Health data while the iPhone is **unlocked**. Set
+each automation to run every 1–4 hours — it will catch up whenever the phone is in
+use. For the 2am journal job, the previous day's data will have fully synced long
+before Bede runs.
+
+---
+
+## Read API Reference
+
+All read endpoints require the header `api-key: sk-your-read-token`.
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/metrics/:name` | Returns stored data for a named metric (see enum values above) |
+| `GET /api/workouts` | Returns stored workout records |
+| `POST /api/data` | Write endpoint — used by the iOS app only |
+
+The full list of supported metric names is defined in
+[`server/src/models/MetricName.ts`](https://github.com/HealthyApps/health-auto-export-server/blob/main/server/src/models/MetricName.ts)
+in the upstream repo.
+
+### Example: query yesterday's step count
+
+```bash
+curl -H 'api-key: sk-your-read-token' \
+  https://hae.YOUR_DOMAIN/api/metrics/step_count
+```
+
+---
+
+## Makefile targets
+
+| Target | Description |
+|---|---|
+| `make hae-build` | Build the hae-server image from source |
+| `make hae-start` | Start hae-server and hae-mongo |
+| `make hae-stop` | Stop health services |
+| `make hae-restart` | Restart health services |
+| `make hae-status` | Show container status |
+| `make logs-hae` | Follow logs from both containers |

--- a/docs/health-auto-export.md
+++ b/docs/health-auto-export.md
@@ -1,6 +1,6 @@
 # Health Auto Export Setup
 
-This document covers setting up `hae-server` and `hae-mongo` to receive Apple Health
+This document covers setting up `hae-server` and `hae-influxdb` to receive Apple Health
 data from the [Health Auto Export](https://apple.co/3iqbU2d) iOS app, and how to
 configure the iPhone automations to push data to your server.
 
@@ -8,13 +8,9 @@ configure the iPhone automations to push data to your server.
 
 The health stack (`docker-compose.health.yml`) consists of two services:
 
-- **hae-mongo** — MongoDB 7 database that stores all incoming health data
-- **hae-server** — Node.js REST API that receives POSTs from the iOS app (`/api/data`)
-  and exposes read endpoints (`/api/metrics/:name`, `/api/workouts`) for Bede or other
-  consumers
-
-The upstream project is [HealthyApps/health-auto-export-server](https://github.com/HealthyApps/health-auto-export-server),
-vendored here as a git submodule at `./hae-server`.
+- **hae-influxdb** — InfluxDB 2 time-series database that stores all incoming health data
+- **hae-server** — [irvinlim/apple-health-ingester](https://github.com/irvinlim/apple-health-ingester)
+  receives POSTs from the iOS app and writes them to InfluxDB
 
 ---
 
@@ -22,43 +18,38 @@ vendored here as a git submodule at `./hae-server`.
 
 ### 1. Generate API tokens
 
-Tokens must start with `sk-`. Generate two (one for writing, one for reading):
+Generate a write token for the iOS app and a separate admin token for InfluxDB:
 
 ```bash
-echo "sk-$(openssl rand -hex 32)"   # run twice
+openssl rand -hex 32   # HAE_WRITE_TOKEN — iOS app uses this to POST data
+openssl rand -hex 32   # HAE_INFLUXDB_TOKEN — InfluxDB admin token
+openssl rand -hex 32   # HAE_INFLUXDB_PASSWORD — InfluxDB admin password
 ```
 
 ### 2. Add environment variables to `.env`
 
 ```bash
-HAE_MONGO_USERNAME=admin
-HAE_MONGO_PASSWORD=your_secure_mongo_password
+# iOS app write token
+HAE_WRITE_TOKEN=your-secure-hae-write-token
 
-# Token the iOS app sends when POSTing data
-HAE_WRITE_TOKEN=sk-your-write-token
-
-# Token Bede (or Grafana) uses when reading data
-HAE_READ_TOKEN=sk-your-read-token
+# InfluxDB credentials
+HAE_INFLUXDB_USERNAME=admin
+HAE_INFLUXDB_PASSWORD=your-secure-influxdb-password
+HAE_INFLUXDB_TOKEN=your-secure-influxdb-admin-token
+HAE_INFLUXDB_ORG=health
+HAE_INFLUXDB_METRICS_BUCKET=metrics
+HAE_INFLUXDB_WORKOUTS_BUCKET=workouts
 ```
-
-Both token values **must start with `sk-`** — the server's auth middleware enforces
-this and will return 401 for any token without the prefix.
 
 ### 3. Build and start
 
-The `hae-server` image is built from source (git submodule). Initialise the submodule
-if you haven't already:
-
 ```bash
-git submodule update --init hae-server
-make hae-build
 make hae-start
 ```
 
 Or it's included in the full stack:
 
 ```bash
-make build   # builds all custom images including hae-server
 make start   # starts everything
 ```
 
@@ -66,27 +57,18 @@ make start   # starts everything
 
 ```bash
 make hae-status     # both containers should show Up
-make logs-hae       # hae-server should print "Connected successfully to health-auto-export"
+make logs-hae       # hae-server should show it connected to InfluxDB
 ```
 
-Test the write endpoint from the server:
+Test the write endpoint:
 
 ```bash
-docker exec hae-server wget -q -O- \
-  --post-data='{"data":[]}' \
-  --header='Content-Type: application/json' \
-  --header='api-key: sk-your-write-token' \
-  http://localhost:3001/api/data
-# Expected: {"metrics":{"success":true,...},"workouts":{"success":true,...}}
-```
-
-Test a read endpoint:
-
-```bash
-docker exec hae-server wget -q -O- \
-  --header='api-key: sk-your-read-token' \
-  'http://localhost:3001/api/metrics/step_count'
-# Expected: [] (empty until data has been synced from iPhone)
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer your-write-token" \
+  -H "Content-Type: application/json" \
+  -d '{"data":[]}' \
+  https://hae.YOUR_DOMAIN/api/healthautoexport/v1/influxdb/ingest
+# Expected: 200
 ```
 
 ---
@@ -102,9 +84,9 @@ to trigger a first sync.
 | Setting | Value |
 |---|---|
 | Automation Type | REST API |
-| URL | `https://hae.YOUR_DOMAIN/api/data` |
-| Header key | `api-key` |
-| Header value | `HAE_WRITE_TOKEN` value from `.env` |
+| URL | `https://hae.YOUR_DOMAIN/api/healthautoexport/v1/influxdb/ingest` |
+| Header key | `Authorization` |
+| Header value | `Bearer <HAE_WRITE_TOKEN value from .env>` |
 | Data Type | Health Metrics |
 | Export Format | JSON |
 | Aggregate Data | On |
@@ -114,20 +96,20 @@ to trigger a first sync.
 
 Recommended metrics to enable (maps to what Bede uses in the journal):
 
-| Metric name in app | Enum value (read API) |
-|---|---|
-| Sleep Analysis | `sleep_analysis` |
-| Step Count | `step_count` |
-| Heart Rate Variability | `heart_rate_variability` |
-| Resting Heart Rate | `resting_heart_rate` |
-| Active Energy | `active_energy` |
-| Apple Exercise Time | `apple_exercise_time` |
-| Apple Stand Time | `apple_stand_time` |
-| Apple Move Time | `apple_move_time` |
-| Mindful Minutes | `mindful_minutes` |
-| State of Mind | `state_of_mind` |
+| Metric name in app |
+|---|
+| Sleep Analysis |
+| Step Count |
+| Heart Rate Variability |
+| Resting Heart Rate |
+| Active Energy |
+| Apple Exercise Time |
+| Apple Stand Time |
+| Apple Move Time |
+| Mindful Minutes |
+| State of Mind |
 
-You can enable additional metrics freely — they are stored in MongoDB and can be
+You can enable additional metrics freely — they are stored in InfluxDB and can be
 queried later without any server changes.
 
 ### Automation 2 — Workouts
@@ -155,26 +137,13 @@ before Bede runs.
 
 ---
 
-## Read API Reference
+## Querying data
 
-All read endpoints require the header `api-key: sk-your-read-token`.
+Health data is stored in InfluxDB and accessible via:
 
-| Endpoint | Description |
-|---|---|
-| `GET /api/metrics/:name` | Returns stored data for a named metric (see enum values above) |
-| `GET /api/workouts` | Returns stored workout records |
-| `POST /api/data` | Write endpoint — used by the iOS app only |
-
-The full list of supported metric names is defined in
-[`server/src/models/MetricName.ts`](https://github.com/HealthyApps/health-auto-export-server/blob/main/server/src/models/MetricName.ts)
-in the upstream repo.
-
-### Example: query yesterday's step count
-
-```bash
-curl -H 'api-key: sk-your-read-token' \
-  https://hae.YOUR_DOMAIN/api/metrics/step_count
-```
+- **InfluxDB UI**: `https://influxdb.YOUR_DOMAIN` — interactive query builder and dashboards
+- **Flux queries**: query via the InfluxDB API using `HAE_INFLUXDB_TOKEN`
+- **Bede**: reads directly from InfluxDB using the admin token
 
 ---
 
@@ -183,7 +152,7 @@ curl -H 'api-key: sk-your-read-token' \
 | Target | Description |
 |---|---|
 | `make hae-build` | Build the hae-server image from source |
-| `make hae-start` | Start hae-server and hae-mongo |
+| `make hae-start` | Start hae-server and hae-influxdb |
 | `make hae-stop` | Stop health services |
 | `make hae-restart` | Restart health services |
 | `make hae-status` | Show container status |


### PR DESCRIPTION
## Summary

- Adds `docker-compose.health.yml` with two new services:
  - `hae-influxdb` — InfluxDB 2 time-series database for health metrics storage, with Traefik route at `influxdb.DOMAIN`
  - `hae-server` — [`irvinlim/apple-health-ingester`](https://github.com/irvinlim/apple-health-ingester) pre-built image that receives Health Auto Export POSTs and writes to InfluxDB, routed at `hae.DOMAIN`
- Both services use `admin-secure` middleware (VPN/local only)
- Increased Traefik `respondingTimeout` to 300s on websecure entrypoint to handle large history exports
- Adds Bede to the `homeserver` Docker network so it can query `hae-influxdb:8086` directly
- Updates `bede/CLAUDE.md.example` with InfluxDB connection details and health data query instructions
- Adds `docs/health-auto-export.md` setup guide

**iPhone setup:** In Health Auto Export app, configure a REST API automation pointing to `https://hae.DOMAIN/api/healthautoexport/v1/influxdb/ingest` with `Authorization: Bearer <HAE_WRITE_TOKEN>`, export format JSON.

This completes step 1 of the automated daily journal implementation plan.

## Test plan

- [x] `hae-influxdb` and `hae-server` containers start and stay healthy
- [x] Traefik routes `hae.DOMAIN` and `influxdb.DOMAIN` correctly
- [x] iPhone Health Auto Export successfully POSTs data (28 metrics, 4,458 points ingested)
- [x] InfluxDB UI accessible at `influxdb.DOMAIN`
- [x] Bede can query InfluxDB directly via `http://hae-influxdb:8086`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)