### PR TITLE
docs: refresh README, SERVICES, and ARCHITECTURE for AI / location / health additions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -265,8 +265,15 @@ graph TB
     subgraph L5["Layer 5: Application Services"]
         direction LR
         Admin["Admin Interfaces
-        n8n, AdGuard
-        Grafana, Prometheus"]
+        Traefik Dashboard, AdGuard, n8n
+        Homepage, Homepage API
+        Grafana, Prometheus, Alertmanager
+        workspace-mcp, owntracks-recorder
+        hae-server, hae-influxdb"]
+        Internal["Internal-Only Services
+        bede (Telegram outbound)
+        data-mcp, mosquitto
+        node-exporter, cadvisor"]
         Webhooks["Public Webhooks
         Future"]
     end
@@ -296,6 +303,7 @@ graph TB
     Traefik -->|Apply Middleware| AdminSecure
     Traefik -->|Apply Middleware| WebhookSecure
     AdminSecure -->|IP Check Pass| Admin
+    AdminSecure -->|IP Check Pass| Internal
     WebhookSecure -->|No IP Restriction| Webhooks
 
     %% Security monitoring
@@ -320,7 +328,7 @@ graph TB
     class WG,VPNSubnet layer2
     class Traefik,AdminSecure,WebhookSecure layer3
     class Fail2ban layer4
-    class Admin,Webhooks layer5
+    class Admin,Internal,Webhooks layer5
     class PromAlerts,Alertmanager layer6
 ```
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,6 +58,29 @@ graph TB
         WorkspaceMCP["workspace-mcp
         Google Workspace API
         :8000"]
+        DataMCP["data-mcp
+        Personal Data MCP
+        :8000 (internal)"]
+    end
+
+    subgraph Location["Location Services
+    docker-compose.location.yml"]
+        OwnTracks["owntracks-recorder
+        Location API
+        :8083"]
+        Mosquitto["mosquitto
+        MQTT sidecar
+        :1883 (internal)"]
+    end
+
+    subgraph Health["Health Services
+    docker-compose.health.yml"]
+        HAEServer["hae-server
+        Health ingest API
+        :8080"]
+        InfluxDB["hae-influxdb
+        InfluxDB v2
+        :8086"]
     end
 
     subgraph Monitoring["Monitoring Stack
@@ -97,6 +120,9 @@ graph TB
         GrafanaData[(Grafana Config)]
         PrometheusData[(Prometheus TSDB)]
         WireGuardData[(WireGuard Configs)]
+        OwnTracksData[(OwnTracks Store)]
+        InfluxData[(Health InfluxDB)]
+        BedeVault[(Bede Vault Data)]
     end
 
     %% External connections
@@ -120,6 +146,9 @@ graph TB
     Traefik -->|*.domain routing| Alertmanager
     Traefik -->|*.domain routing| Homepage
     Traefik -->|mcp.domain routing| WorkspaceMCP
+    Traefik -->|owntracks.domain routing| OwnTracks
+    Traefik -->|hae.domain routing| HAEServer
+    Traefik -->|influxdb.domain routing| InfluxDB
 
     %% DNS resolution
     AdGuard -.->|DNS Rewrites| Traefik
@@ -141,7 +170,12 @@ graph TB
     Bede -->|Claude API| Internet
     Bede -->|Telegram Bot API| Internet
     Bede -.->|MCP Protocol| WorkspaceMCP
+    Bede -.->|MCP Protocol| DataMCP
     WorkspaceMCP -->|Google Workspace APIs| Internet
+    DataMCP -->|Reads| OwnTracks
+    DataMCP -->|Reads| InfluxDB
+    OwnTracks -->|Publishes via sidecar| Mosquitto
+    HAEServer -->|Writes metrics/workouts| InfluxDB
 
     %% Certificate management
     Certbot -->|Copies Certs| TraefikData
@@ -154,6 +188,9 @@ graph TB
     Grafana -.->|Stores| GrafanaData
     Prometheus -.->|Stores| PrometheusData
     VPN -.->|Stores| WireGuardData
+    OwnTracks -.->|Stores| OwnTracksData
+    InfluxDB -.->|Stores| InfluxData
+    Bede -.->|Stores| BedeVault
 
     classDef external fill:#ff6b6b,stroke:#c92a2a,stroke-width:2px,color:#fff
     classDef network fill:#4dabf7,stroke:#1971c2,stroke-width:2px,color:#fff
@@ -169,8 +206,8 @@ graph TB
     class AdGuard,N8N core
     class Prometheus,Grafana,Alertmanager,NodeExporter,CAdvisor monitoring
     class Homepage,HomepageAPI dashboard
-    class Bede,WorkspaceMCP ai
-    class AdGuardData,N8NData,TraefikData,GrafanaData,PrometheusData,WireGuardData data
+    class Bede,WorkspaceMCP,DataMCP ai
+    class AdGuardData,N8NData,TraefikData,GrafanaData,PrometheusData,WireGuardData,OwnTracksData,InfluxData,BedeVault data
     class Certbot system
 ```
 
@@ -337,6 +374,22 @@ graph TD
     Homepage["Homepage
     Dashboard UI"]
 
+    %% AI / data / health / location services
+    Bede["Bede
+    Telegram Assistant"]
+    WorkspaceMCP["workspace-mcp
+    Google Workspace MCP"]
+    DataMCP["data-mcp
+    Personal Data MCP"]
+    OwnTracks["owntracks-recorder
+    Location API"]
+    Mosquitto["mosquitto
+    MQTT sidecar"]
+    HAEServer["hae-server
+    Health ingest API"]
+    InfluxDB["hae-influxdb
+    Time-series DB"]
+
     %% Dependencies
     Docker --> Traefik
     Docker --> Fail2ban
@@ -349,12 +402,23 @@ graph TD
     Docker --> Alertmanager
     Docker --> HomepageAPI
     Docker --> Homepage
+    Docker --> Bede
+    Docker --> WorkspaceMCP
+    Docker --> DataMCP
+    Docker --> OwnTracks
+    Docker --> Mosquitto
+    Docker --> HAEServer
+    Docker --> InfluxDB
 
     Traefik --> N8N
     Traefik --> Grafana
     Traefik --> Prometheus
     Traefik --> Alertmanager
     Traefik --> Homepage
+    Traefik --> WorkspaceMCP
+    Traefik --> OwnTracks
+    Traefik --> HAEServer
+    Traefik --> InfluxDB
 
     N8NInit --> N8N
 
@@ -364,6 +428,12 @@ graph TD
     Prometheus --> Alertmanager
 
     HomepageAPI --> Homepage
+    Mosquitto --> OwnTracks
+    InfluxDB --> HAEServer
+    InfluxDB --> DataMCP
+    OwnTracks --> DataMCP
+    WorkspaceMCP --> Bede
+    DataMCP --> Bede
 
     Certbot -.->|Provides Certs| Traefik
     AdGuard -.->|DNS Resolution| Traefik
@@ -377,12 +447,14 @@ graph TD
     classDef core fill:#51cf66,stroke:#2b8a3e,stroke-width:2px,color:#fff
     classDef monitoring fill:#ffd43b,stroke:#f08c00,stroke-width:2px,color:#000
     classDef dashboard fill:#da77f2,stroke:#9c36b5,stroke-width:2px,color:#fff
+    classDef ai fill:#845ef7,stroke:#6741d9,stroke-width:2px,color:#fff
 
     class Docker,WireGuard,Certbot system
     class Traefik,Fail2ban network
     class AdGuard,N8NInit,N8N core
     class Prometheus,NodeExporter,CAdvisor,Grafana,Alertmanager monitoring
     class HomepageAPI,Homepage dashboard
+    class Bede,WorkspaceMCP,DataMCP,OwnTracks,Mosquitto,HAEServer,InfluxDB ai
 ```
 
 ---
@@ -506,11 +578,14 @@ graph LR
 ## Key Architecture Patterns
 
 ### Multi-File Compose Organization
-The stack uses four compose files for logical separation:
+The stack uses multiple compose files for logical separation:
 - **docker-compose.yml**: Core services (AdGuard, n8n)
 - **docker-compose.network.yml**: Network & Security (Traefik, Fail2ban)
 - **docker-compose.monitoring.yml**: Monitoring stack (Prometheus, Grafana, Alertmanager, exporters)
 - **docker-compose.dashboard.yml**: Dashboard (Homepage, Homepage API)
+- **docker-compose.ai.yml**: AI assistant services (Bede, workspace-mcp, data-mcp)
+- **docker-compose.location.yml**: Location stack (owntracks-recorder, mosquitto)
+- **docker-compose.health.yml**: Health ingestion stack (hae-server, hae-influxdb)
 
 ### Domain-Based Routing
 All services accessible via `https://<service>.${DOMAIN}`:
@@ -560,8 +635,12 @@ tar -czf backup.tar.gz data/ .env
 - **Grafana** - https://grafana.${DOMAIN}
 - **Prometheus** - https://prometheus.${DOMAIN}
 - **Alertmanager** - https://alerts.${DOMAIN}
-- **Homepage** - https://home.${DOMAIN}
+- **Homepage** - https://homepage.${DOMAIN}
 - **Traefik Dashboard** - https://traefik.${DOMAIN}
+- **Workspace MCP** - https://mcp.${DOMAIN}
+- **OwnTracks Recorder** - https://owntracks.${DOMAIN}
+- **HAE Server** - https://hae.${DOMAIN}
+- **InfluxDB** - https://influxdb.${DOMAIN}
 
 ### Direct Access (monitoring, not exposed externally)
 - **9090** - Prometheus (metrics)
@@ -594,4 +673,3 @@ graph LR
 ```
 
 **Important**: This stack runs on a dedicated home server, not the development machine. Local `docker compose up` will not replicate the production environment without proper DNS setup. Always deploy and troubleshoot on the actual server via SSH.
-

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A complete self-hosted infrastructure for home automation, AI, and network services using Docker Compose.
 
+## 🆕 Recent Changes (late March → mid April 2026)
+
+- Added **data-mcp** so Bede can query personal data from OwnTracks, Apple Health (InfluxDB), and vault git history.
+- Added **OwnTracks location services** (`owntracks-recorder` + internal `mosquitto`) in `docker-compose.location.yml`.
+- Added **Apple Health stack** (`hae-server` + `hae-influxdb`) in `docker-compose.health.yml`.
+- Removed **OpenClaw** and standardized AI assistant workflows on Bede.
+
 ## 🚀 Services
 
 **Core Services:**
@@ -9,6 +16,8 @@ A complete self-hosted infrastructure for home automation, AI, and network servi
 - **[n8n](https://github.com/n8n-io/n8n)** - Workflow automation platform
 - **[WireGuard](https://github.com/wireguard)** - VPN for secure remote access
 - **[Traefik](https://github.com/traefik/traefik)** - Reverse proxy for domain-based service access
+- **OwnTracks Recorder** - Location timeline ingestion and query API
+- **HAE Server + InfluxDB** - Apple Health ingestion and time-series storage
 
 **Monitoring Stack:**
 - **[Grafana](https://github.com/grafana/grafana)** - Metrics visualization and dashboards
@@ -137,6 +146,10 @@ All services are accessible via domain names on your local network:
 - **Prometheus:** `https://prometheus.${DOMAIN}` (Metrics)
 - **Alertmanager:** `https://alerts.${DOMAIN}` (Alerts)
 - **Homepage:** `https://homepage.${DOMAIN}` (Dashboard)
+- **OwnTracks Recorder:** `https://owntracks.${DOMAIN}` (Location history API)
+- **Health Auto Export endpoint:** `https://hae.${DOMAIN}` (Apple Health ingest)
+- **InfluxDB:** `https://influxdb.${DOMAIN}` (Health data UI/API)
+- **Workspace MCP OAuth:** `https://mcp.${DOMAIN}` (Google Workspace MCP OAuth callback/UI)
 
 **Note:** Services are accessible via domain names thanks to Traefik reverse proxy and AdGuard Home DNS. Your devices must use AdGuard Home as their DNS server (configured automatically if DHCP points to the server).
 

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -32,6 +32,11 @@ Currently deployed and active services.
   - Check SSL certificates
   - View access logs
 
+#### Fail2ban
+- **Purpose:** Intrusion prevention (brute-force/scanner detection, automated bans)
+- **Access:** No web UI (runs as security sidecar)
+- **Authentication:** N/A
+
 ### Core Services
 
 #### AdGuard Home
@@ -113,6 +118,39 @@ Currently deployed and active services.
 - **Port:** 8000 (internal)
 - **Authentication:** OAuth 2.0 with Google
 
+#### data-mcp
+- **Purpose:** MCP server for personal data tools used by Bede
+- **Access:** Internal only (container-to-container)
+- **Authentication:** Environment token/config based access to upstream systems
+- **Data Sources:**
+  - Obsidian vault git history
+  - OwnTracks Recorder API
+  - Apple Health InfluxDB buckets
+
+### Location Services
+
+#### owntracks-recorder
+- **Purpose:** Receives OwnTracks phone HTTP posts and serves location history API
+- **Access:** https://owntracks.${DOMAIN}
+- **Authentication:** IP-restricted via Traefik `admin-secure`
+
+#### mosquitto
+- **Purpose:** Internal MQTT broker sidecar required by owntracks-recorder
+- **Access:** Internal only
+- **Authentication:** Internal network-only usage in this stack
+
+### Health Services
+
+#### hae-server
+- **Purpose:** Apple Health Auto Export ingest API
+- **Access:** https://hae.${DOMAIN}
+- **Authentication:** Bearer token (`HAE_WRITE_TOKEN`)
+
+#### hae-influxdb
+- **Purpose:** Time-series storage for health metrics/workouts
+- **Access:** https://influxdb.${DOMAIN}
+- **Authentication:** InfluxDB credentials + token
+
 ---
 
 ## Quick Reference
@@ -129,6 +167,10 @@ Currently deployed and active services.
 | Alertmanager | https://alerts.${DOMAIN} | http://IP:9093 |
 | Bede | Telegram bot | N/A |
 | workspace-mcp | https://mcp.${DOMAIN} | N/A |
+| data-mcp | Internal only | N/A |
+| owntracks-recorder | https://owntracks.${DOMAIN} | N/A |
+| hae-server | https://hae.${DOMAIN} | N/A |
+| hae-influxdb | https://influxdb.${DOMAIN} | N/A |
 
 ---
 
@@ -151,7 +193,6 @@ Services queued for implementation.
 ### Infrastructure & Security
 - [ ] **[Ollama](https://github.com/ollama/ollama)** - Run large language models locally
 - [ ] **[Watchtower](https://github.com/containrrr/watchtower)** - A process for automating Docker container base image updates
-- [ ] **[Fail2ban](https://github.com/fail2ban/fail2ban)** - Daemon to ban hosts that cause multiple authentication errors
 - [ ] **[SearXNG](https://github.com/searxng/searxng)** - Free internet metasearch engine which aggregates results from various search services
 - [ ] **[CrowdSec](https://github.com/crowdsecurity/crowdsec)** - Open-source and participative security solution with crowdsourced protection against malicious IPs
 - [ ] **[Nginx Proxy Manager](https://github.com/NginxProxyManager/nginx-proxy-manager)** - Docker container for managing Nginx proxy hosts with a simple, powerful interface (alternative to Traefik)


### PR DESCRIPTION
### Motivation

- Capture recent stack changes (late March → mid April 2026) in the top-level docs so operators can find new services and endpoints quickly.
- Reflect the new AI data integration work (Bede + `data-mcp`) and newly added Location and Health stacks in the service catalog and architecture diagrams.
- Remove stale references to the previously-trialed OpenClaw assistant and keep docs consistent with current compose files.

### Description

- Updated `README.md` with a new "Recent Changes" section and added service access entries for `owntracks`, `hae`, `influxdb`, and the `mcp` OAuth endpoint, and noted the OpenClaw removal.
- Extended `SERVICES.md` to add `fail2ban` under management services, introduce `data-mcp`, add a Location section (`owntracks-recorder` + `mosquitto`), add a Health section (`hae-server` + `hae-influxdb`), and updated the quick-reference table.
- Expanded `ARCHITECTURE.md` mermaid diagrams and narrative to include the new AI/data layer (`data-mcp`), Location compose file, Health compose file, updated data flow edges (OwnTracks → data-mcp, HAE → InfluxDB → data-mcp), and corrected internal hostname for the Homepage to `homepage.${DOMAIN}`.
- Minor housekeeping: updated multi-file compose list to include `docker-compose.ai.yml`, `docker-compose.location.yml`, and `docker-compose.health.yml` and adjusted other doc text for consistency.

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and it returned no problems.
- Verified repository status with `git status --short` to confirm the intended files were modified and staged.
- Committed the changes and amended the commit to include a final architecture tweak; the commit succeeded (no automated unit tests were run as part of this docs-only change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de02ff40a88328ad4749344e231883)