### PR TITLE
feat(data-mcp): add get_weather MCP tool

### DIFF
--- a/bede/CLAUDE.md.example
+++ b/bede/CLAUDE.md.example
@@ -53,7 +53,7 @@ All tools handle timezone conversion internally — pass local dates, never UTC.
 - `get_heart_rate(date)` — resting heart rate and HRV
 
 **Weather tools:**
-- `get_weather()` — current BOM observations and 7-day forecast (temperature, rain, UV, wind)
+- `get_weather()` — current BOM observations and 7-day forecast for the configured location (`BOM_LOCATION` in `.env`)
 
 **Vault tools** (data collected nightly from the user's Mac):
 - `get_screen_time(date, device)` — app and web domain usage by duration

--- a/bede/CLAUDE.md.example
+++ b/bede/CLAUDE.md.example
@@ -52,6 +52,9 @@ All tools handle timezone conversion internally — pass local dates, never UTC.
 - `get_workouts(date)` — workout type, start time, duration, and calories
 - `get_heart_rate(date)` — resting heart rate and HRV
 
+**Weather tools:**
+- `get_weather()` — current BOM observations and 7-day forecast (temperature, rain, UV, wind)
+
 **Vault tools** (data collected nightly from the user's Mac):
 - `get_screen_time(date, device)` — app and web domain usage by duration
 - `get_safari_history(date, device, domain_filter)` — Safari page visits
@@ -66,15 +69,6 @@ Default timezone is `Australia/Sydney`; pass `timezone=` to override.
 **Not available:** Medications and state of mind are not exported by Health Auto Export
 via the server sync protocol — neither the affiliated HAE server nor any known ingester
 supports these data types. They cannot be queried.
-
-## Homepage API
-
-Internal backend providing system metrics and integrations.
-
-**Connection:**
-- URL: `http://homepage-api:5000`
-- Weather: `GET /api/weather` — current conditions for the configured location
-- Health check: `GET /api/health`
 
 ## Google Account
 

--- a/bede/data-mcp/server.py
+++ b/bede/data-mcp/server.py
@@ -2,7 +2,7 @@
 
 from fastmcp import FastMCP
 
-from sources import health, location, vault
+from sources import health, location, vault, weather
 from sources.db import init_db
 
 mcp = FastMCP("personal-data")
@@ -224,6 +224,21 @@ def get_medications(
         timezone: Olson timezone name.
     """
     return health.get_medications(date, timezone=timezone)
+
+
+# ---------------------------------------------------------------------------
+# Weather tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+async def get_weather() -> dict:
+    """Return current weather observations and forecast for the configured location.
+
+    Includes current temperature, conditions, wind, humidity, and a 7-day
+    daily forecast with rain chance, UV index, and sunrise/sunset times.
+    Data sourced from the Australian Bureau of Meteorology.
+    """
+    return await weather.get_weather()
 
 
 # ---------------------------------------------------------------------------

--- a/bede/data-mcp/sources/weather.py
+++ b/bede/data-mcp/sources/weather.py
@@ -1,0 +1,13 @@
+"""Weather data via homepage-api BOM endpoint."""
+
+import httpx
+
+HOMEPAGE_API_URL = "http://homepage-api:5000"
+
+
+async def get_weather() -> dict:
+    """Fetch current weather and forecast from BOM via homepage-api."""
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(f"{HOMEPAGE_API_URL}/api/bom/weather")
+        resp.raise_for_status()
+        return resp.json()

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -95,6 +95,7 @@ services:
       - 8000
     networks:
       - default
+      - homeserver
       - location
 
 volumes:


### PR DESCRIPTION
## Summary
- Adds a `get_weather()` MCP tool to data-mcp so Bede can access BOM weather data during nightly journal creation
- Proxies the existing homepage-api `/api/bom/weather` endpoint via httpx (already a dependency)
- Adds `homeserver` network to data-mcp container so it can reach homepage-api

## Context
Bede couldn't include weather in the nightly journal because BOM data was only available as an HTTP endpoint on homepage-api, and Claude CLI can only call MCP tools — not make arbitrary HTTP requests.

## Test plan
- [ ] `make validate` passes
- [ ] Deploy and verify `data-mcp` container starts without errors
- [ ] Call `get_weather()` tool from Bede and confirm BOM data is returned
- [ ] Verify nightly journal includes weather summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)