### PR TITLE
docs: simplify CLAUDE.md and add security audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ __pycache__/
 ehthumbs.db
 Thumbs.db
 # Claude Code — ignore personal/local config but commit shared skills
+CLAUDE.local.md
 .claude/settings.local.json
 .claude/todos.json
 .claude/*.local
 .worktrees/
-bede/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,745 +1,100 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Project Overview
 
-This is a self-hosted infrastructure stack running on Docker Compose, providing home automation, workflow automation, VPN access, DNS/ad-blocking, and comprehensive monitoring. Services are accessed via domain-based routing through Traefik reverse proxy with Let's Encrypt SSL certificates.
-
-## Development Environment Context
-
-**IMPORTANT**: This stack is designed to run on a dedicated home server (e.g., Ubuntu Server at 192.168.1.100), not on the development machine where code is edited.
-
-**Typical workflow**:
-- Code changes are made on the development machine (e.g., MacBook)
-- Changes are committed and pushed to git
-- Changes are deployed to the actual home server via SSH or git pull
-- Troubleshooting is done by SSHing into the home server and checking logs there
-
-**What this means for development**:
-- Running `make start` or `docker compose up` on the development machine **will not help with troubleshooting** production issues
-- DNS-based routing requires AdGuard Home to be the network DNS server, which only works on the home server's network
-- SSL certificates are obtained for the registered domain and won't work locally without proper DNS setup
-- When debugging issues, use SSH to connect to the home server and run commands there:
-  ```bash
-  ssh user@192.168.1.100
-  cd /path/to/home-server-stack
-  make logs  # View actual logs from the running services
-  make status  # Check service health
-  ```
-- Configuration validation (`make validate`) can be done locally before pushing changes
-- For local testing of docker-compose syntax, you can run validation but not the actual services
-
-## Common Development Commands
-
-### Environment Setup
-```bash
-# One-time: Install Docker from official repository (if using snap Docker)
-# Check: which docker (if shows /snap/bin/docker, run the installer)
-./scripts/system/install-docker-official.sh
-
-# One-time: Add user to docker group (enables docker commands without sudo)
-./scripts/system/setup-user-permissions.sh
-
-# Copy environment template and configure
-cp .env.example .env
-# Edit .env - set SERVER_IP, DOMAIN, passwords, GANDIV5_PERSONAL_ACCESS_TOKEN
-
-# Validate configuration
-make validate
-```
-
-### Service Management
-```bash
-# First-time setup (includes SSL cert setup and AdGuard DNS configuration)
-make setup
-
-# Start all services (core + monitoring)
-make start
-
-# Stop all services
-make stop
-
-# Restart services
-make restart
-
-# View service status
-make status
-```
-
-### Updates & Maintenance
-```bash
-# Pull latest images and restart services
-make update
-
-# Pull images without restarting
-make pull
-
-# Build custom services from source (homepage-api)
-make build-custom
-
-# Build all services (includes custom services)
-make build
-```
-
-### Logs & Debugging
-```bash
-# View all service logs (follow mode)
-make logs
-
-# View specific service logs
-make logs-n8n
-make logs-homepage
-make logs-bede
-
-# View logs directly (useful for other services)
-docker compose -f docker-compose.yml -f docker-compose.monitoring.yml logs -f [service-name]
-```
-
-### SSL Certificate Management
-```bash
-# Complete Let's Encrypt SSL setup (certbot + auto-renewal)
-make ssl-setup
-
-# Test renewal (dry run)
-make ssl-renew-test
-
-# Manual certificate operations (advanced)
-sudo certbot certificates                    # View certificate info
-sudo certbot renew --dry-run                # Test renewal
-sudo certbot renew --force-renewal          # Force renewal
-sudo tail -f /var/log/certbot-traefik-reload.log  # View renewal logs
-```
-
-### WireGuard VPN Management
-
-**How it all fits together:**
-
-WireGuard runs as a system service (`wg-quick@wg0`), not a Docker container. This ensures VPN access stays up even when the Docker stack is restarted.
-
-There are two distinct setup phases:
-
-**One-time setup** (new server only):
-```
-make wireguard-install       # Install the wireguard apt package
-make wireguard-setup         # Generate server keys, write /etc/wireguard/wg0.conf,
-                             # enable and start wg-quick@wg0
-make start                   # Start the Docker stack first
-make wireguard-routing       # Add iptables rules so VPN clients can reach Docker
-                             # containers and the LAN. Must run AFTER make start
-                             # because it inspects the Docker bridge network.
-sudo ./scripts/wireguard/wireguard-add-peer.sh <name>
-                             # Add a client device. Run once per device.
-                             # Writes to /etc/wireguard/wg0.conf and saves the
-                             # client config + QR code to data/wireguard/peers/<name>/
-```
-
-**Ongoing use:**
-```bash
-# Check WireGuard status
-make wireguard-status
-
-# Add VPN peers (clients) one at a time
-sudo ./scripts/wireguard/wireguard-add-peer.sh mydevice
-sudo ./scripts/wireguard/wireguard-add-peer.sh phone
-
-# List and manage existing peers
-make wireguard-peers
-
-# Test VPN routing and connectivity
-make wireguard-test
-
-# View detailed status
-sudo wg show
-sudo systemctl status wg-quick@wg0
-```
-
-### Service Configuration
-
-AdGuard DNS rewrites, Traefik password, and dynamic DNS (if `WIREGUARD_DDNS_SUBDOMAIN` is set) are configured automatically by `make setup`. To reconfigure manually:
-
-```bash
-# Configure AdGuard DNS rewrites
-./scripts/adguard/setup-adguard-dns.sh
-
-# Regenerate Traefik dashboard password
-./scripts/traefik/setup-traefik-password.sh
-```
-
-### Dashboard Management
-
-The Homepage dashboard is managed with the main service targets:
-
-```bash
-make start    # Start all services including Homepage
-make stop     # Stop all services
-make restart  # Restart all services
-make logs     # View all service logs
-make logs-homepage  # View Homepage logs only
-make status   # Check all service health
-```
-
-### AI Services Management (Bede Assistant)
-
-AI services can be managed separately from the main stack:
-
-```bash
-# Start AI services only (includes Bede and workspace-mcp)
-make bede-start
-
-# Stop AI services only
-make bede-stop
-
-# Restart AI services only
-make bede-restart
-
-# Build AI services from source
-make bede-build
-
-# Check AI services status
-make bede-status
-
-# View AI service logs
-make logs-bede
-```
-
-**Note**: AI services are included in main stack commands by default. Use individual AI targets for development or troubleshooting specific AI components.
-
-### Testing & Validation
-```bash
-# Test domain-based access for all services
-make test-domain-access
-
-# Manually test DNS resolution
-dig @${SERVER_IP} n8n.${DOMAIN} +short
-
-# Validate docker-compose configuration
-make validate
-
-# Check environment file exists
-make env-check
-```
-
-### Cleanup
-```bash
-# Remove containers and volumes (preserves ./data/)
-make clean
-
-# Nuclear option: remove everything including ./data/ (DESTRUCTIVE)
-make purge
-```
-
-## Architecture & Key Concepts
-
-### Multi-File Docker Compose
-The stack uses **five compose files** organized by logical function:
-- `docker-compose.yml` - Core services (AdGuard, n8n) - user-facing services that "do stuff"
-- `docker-compose.network.yml` - Network & Security (Traefik, Fail2ban) - infrastructure layer
-- `docker-compose.monitoring.yml` - Monitoring stack (Prometheus, Grafana, Alertmanager, exporters)
-- `docker-compose.dashboard.yml` - Dashboard (Homepage, Homepage API)
-- `docker-compose.ai.yml` - AI services (Bede assistant, workspace-mcp)
-
-**Note on WireGuard VPN**: WireGuard is installed as a **system service** (not Docker) to ensure VPN access remains available when Docker services are restarted or stopped. See "WireGuard VPN Management" section above.
-
-The Makefile combines all files by default: `docker compose -f docker-compose.yml -f docker-compose.network.yml -f docker-compose.monitoring.yml -f docker-compose.dashboard.yml -f docker-compose.ai.yml`
-
-This organization provides:
-- **Clear separation of concerns** - Easy to understand what each file contains
-- **Logical grouping** - Services grouped by function (core, network, monitoring, dashboard)
-- **Modular deployment** - Can deploy subsets if needed (e.g., core + network without monitoring)
-- **Homepage dashboard alignment** - Dashboard sections mirror compose file organization
-
-### Domain-Based Routing Architecture
-Services are accessed via **subdomain.DOMAIN** instead of IP:port combinations:
-
-1. **AdGuard Home** (DNS server on port 53) resolves `*.DOMAIN` to `SERVER_IP`
-2. **Traefik** (reverse proxy on ports 80/443) routes requests based on Host header
-3. Services are discovered automatically via Docker labels: `traefik.http.routers.<service>.rule=Host(\`<service>.${DOMAIN}\`)`
-
-Example flow: `https://n8n.example.com` → DNS resolves to SERVER_IP → Traefik routes to n8n container → HTTPS response
-
-### SSL Certificates with Let's Encrypt (via certbot)
-**Implementation**: Uses **certbot with Gandi DNS plugin** for Let's Encrypt wildcard certificates.
-
-**Why certbot instead of Traefik's built-in ACME?**
-- Traefik v3.2's Lego library (v4.21.0) has compatibility issues with Gandi API v5
-- Manual API tests with Gandi succeed, but Lego consistently returns 403 Forbidden during DNS-01 challenge
-- Root cause: Bug or incompatibility between Lego's Gandi provider and Gandi API v5
-- Solution: Use certbot with `certbot-dns-gandi` plugin which works reliably with same credentials
-- See `scripts/ssl/setup-certbot-gandi.sh` for detailed implementation
-
-**How it works**:
-1. **certbot** generates wildcard certificate for `*.DOMAIN` and `DOMAIN` via DNS-01 challenge
-2. Certificates stored in `/etc/letsencrypt/live/DOMAIN/` (system location)
-3. Copied to `./data/traefik/certs/` for Traefik access via file provider
-4. Traefik configured with file provider to load certificates from `./config/traefik/dynamic-certs.yml`
-5. Post-renewal hook automatically copies renewed certs and restarts Traefik
-
-**Setup Commands**:
-```bash
-# Complete SSL setup (all steps)
-make ssl-setup
-
-# Test renewal (dry run)
-make ssl-renew-test
-```
-
-**Auto-Renewal**:
-- certbot runs twice daily via snap timer
-- Certificates renewed 30 days before expiry (Let's Encrypt = 90 day validity)
-- Post-renewal hook: `/etc/letsencrypt/renewal-hooks/deploy/traefik-reload.sh`
-- Hook copies new certs to Traefik and runs `docker compose restart traefik`
-- Logs: `/var/log/certbot-traefik-reload.log`
-
-**Required Environment Variables**:
-- `DOMAIN` - Registered domain name hosted on Gandi
-- `LETSENCRYPT_EMAIL` - Email for Let's Encrypt notifications
-- `GANDIV5_PERSONAL_ACCESS_TOKEN` - Gandi API token with "Manage domain name technical configurations" permission
-
-**File Locations**:
-- Certificates (source): `/etc/letsencrypt/live/DOMAIN/fullchain.pem`, `privkey.pem`
-- Certificates (Traefik): `./data/traefik/certs/DOMAIN.crt`, `DOMAIN.key`
-- Traefik dynamic config: `./config/traefik/dynamic-certs.yml`
-- Renewal hook: `/etc/letsencrypt/renewal-hooks/deploy/traefik-reload.sh`
-- Gandi credentials: `/etc/letsencrypt/gandi/gandi.ini` (chmod 600)
-
-### Security Architecture
-
-The stack implements **multi-layered defense-in-depth** security:
-
-#### Layer 1: Network Firewall (UFW)
-- Default deny incoming, allow outgoing
-- SSH rate-limited (prevents brute force)
-- WireGuard VPN (UDP 51820) - primary remote access
-- HTTP/HTTPS (80/443) for Traefik reverse proxy
-- Full access for local network (192.168.1.0/24) and VPN clients (10.13.13.0/24)
-- Setup: `./scripts/system/setup-firewall.sh`
-
-#### Layer 2: Traefik Middleware Security
-**admin-secure middleware chain** (applied to all admin interfaces):
-- IP whitelisting: Only RFC1918 (192.168.x.x, 10.x.x.x, 172.16.x.x) allowed
-- Security headers: HSTS, XSS protection, frame deny, content-type nosniff
-- Rate limiting: 10 requests/min (burst 5)
-- Services: n8n, AdGuard, Grafana, Prometheus, Alertmanager, Traefik dashboard
-
-**webhook-secure middleware chain** (ready for future public webhooks):
-- Security headers (same as above)
-- Generous rate limiting: 100 requests/min (burst 50)
-- No IP restrictions (public access)
-
-Middleware definitions in `docker-compose.yml` Traefik service labels.
-
-#### Layer 3: Fail2ban Automated Defense
-- Monitors Traefik access logs for malicious patterns
-- **traefik-auth jail**: 3 x 401 errors → 1 hour ban
-- **traefik-webhook jail**: 20 x rate limit hits → 10 minute ban
-- **traefik-scanner jail**: 10 x 404 errors → 24 hour ban
-- Ignores local/VPN networks from bans
-- Config: `config/fail2ban/`
-
-#### Layer 4: Prometheus Security Monitoring
-- High webhook rate detection (>1 req/sec)
-- Authentication failure monitoring (401 errors)
-- Scanning activity detection (404 errors)
-- Rate limit enforcement tracking (429 errors)
-- Server error monitoring (5xx errors)
-- Traefik and fail2ban availability monitoring
-- Alerts: `monitoring/prometheus/alert_rules.yml` security-alerts group
-
-#### VPN-First Access Model
-- Primary remote access: WireGuard VPN only
-- Admin interfaces: VPN or local network only (enforced by middleware)
-- Future public webhooks: Separate router with webhook-secure middleware
-- See `security-tickets/README.md` for complete security roadmap
+Self-hosted Docker Compose infrastructure stack: home automation, workflow automation, VPN, DNS/ad-blocking, and monitoring. Domain-based routing via Traefik reverse proxy with Let's Encrypt SSL.
+
+## Development Environment
+
+**This stack runs on a dedicated home server, not the dev Mac.**
+
+- Code is edited locally, committed, pushed, and deployed to the server via SSH/git pull
+- `make start` / `docker compose up` on the Mac won't help troubleshoot production
+- DNS routing, SSL certs, and service access only work on the server's network
+- `make validate` works locally for syntax checks
+- For production debugging: SSH into the server, then `make logs` / `make status`
+
+## Make Targets
+
+| Target | Purpose |
+|--------|---------|
+| `make setup` | First-time setup (SSL, DNS, passwords) |
+| `make start` / `stop` / `restart` | Manage all services |
+| `make status` | Service health check |
+| `make logs` | Follow all service logs |
+| `make logs-<service>` | Logs for one service (n8n, homepage, bede, etc.) |
+| `make update` | Pull latest images and restart |
+| `make build` | Build all (includes custom services) |
+| `make validate` | Validate docker-compose config |
+| `make test-domain-access` | Test HTTPS access to all services |
+| `make clean` | Remove containers/volumes (preserves ./data/) |
+| `make purge` | **DESTRUCTIVE** — removes everything including ./data/ |
+
+**Bede AI services** (also included in main targets):
+`make bede-start` / `bede-stop` / `bede-restart` / `bede-build` / `bede-status`
+
+**SSL**: `make ssl-setup` / `ssl-renew-test`
+
+**WireGuard**: `make wireguard-status` / `wireguard-peers` / `wireguard-test` / `wireguard-routing`
+Add peers: `sudo ./scripts/wireguard/wireguard-add-peer.sh <name>`
+
+## Architecture
+
+### Compose File Organization
+- `docker-compose.yml` — Core services (AdGuard, n8n)
+- `docker-compose.network.yml` — Network & security (Traefik, Fail2ban)
+- `docker-compose.monitoring.yml` — Monitoring (Prometheus, Grafana, Alertmanager, exporters)
+- `docker-compose.dashboard.yml` — Dashboard (Homepage, Homepage API)
+- `docker-compose.ai.yml` — AI services (Bede, workspace-mcp, data-mcp, data-ingest)
+
+The Makefile combines all five files by default.
+
+### Domain Routing
+1. **AdGuard Home** (port 53) resolves `*.DOMAIN` → `SERVER_IP`
+2. **Traefik** (ports 80/443) routes by Host header to the correct container
+3. Services register via Docker labels: `Host(\`<service>.${DOMAIN}\`)`
+
+### SSL (certbot, not Traefik ACME)
+Uses certbot with Gandi DNS plugin because Traefik v3.2's Lego library has a bug with Gandi API v5 (returns 403 on DNS-01 challenge despite valid credentials). Certbot generates wildcard certs for `*.DOMAIN`, copies them to `./data/traefik/certs/`, Traefik loads via file provider. Auto-renewal runs twice daily via snap timer with a post-hook that copies certs and restarts Traefik.
+
+### WireGuard VPN
+Runs as a **system service** (`wg-quick@wg0`), not Docker — stays up when Docker restarts. Split tunneling only routes home network and VPN subnet traffic. **Do not use `0.0.0.0/0` for AllowedIPs** unless full tunneling is explicitly required.
+
+### Security Model (Defense in Depth)
+1. **UFW firewall** — default deny, allow SSH/HTTP/HTTPS/WireGuard + local/VPN subnets
+2. **Traefik middleware** — `admin-secure` chain: RFC1918 IP whitelist + security headers + rate limiting on all admin UIs; `webhook-secure` chain for public endpoints
+3. **Fail2ban** — auto-bans on auth failures, scanner patterns, rate limit abuse (config in `config/fail2ban/`)
+4. **Prometheus alerts** — monitors 401s, 404s, 429s, 5xx errors (rules in `monitoring/prometheus/alert_rules.yml`)
 
 ### Data Persistence
-All persistent data is stored in `./data/` using **bind mounts** (not Docker volumes):
-- `./data/adguard/` - DNS configuration and logs
-- `./data/n8n/` - Workflow database and files
-- `./data/wireguard/` - VPN configs and peer keys
-- `./data/traefik/` - SSL certificates and logs
-- `./data/grafana/`, `./data/prometheus/`, etc. - Monitoring data
+All in `./data/` using bind mounts. Backup: `tar -czf backup.tar.gz data/ .env`
 
-Backup strategy: `tar -czf backup.tar.gz data/ .env`
+## Key Patterns
 
-### WireGuard Split Tunneling
-**Critical**: WireGuard is configured for **split tunneling** by default:
-- `WIREGUARD_ALLOWEDIPS=192.168.1.0/24,10.13.13.0/24` routes only home network traffic
-- **DO NOT** use `0.0.0.0/0` unless full tunneling is explicitly required
-- This prevents routing all internet traffic through the VPN
-
-## Important Environment Variables
-
-Required variables in `.env`:
-- `SERVER_IP` - Server's local network IP (e.g., 192.168.1.100)
-- `DOMAIN` - Registered domain name (e.g., example.com) for Let's Encrypt
-- `TIMEZONE` - System timezone (e.g., America/New_York)
-- `GANDIV5_PERSONAL_ACCESS_TOKEN` - Gandi API token for DNS-01 challenge
-- `LETSENCRYPT_EMAIL` - Email for Let's Encrypt certificate notifications
-- `N8N_PASSWORD`, `ADGUARD_PASSWORD`, `GRAFANA_PASSWORD` - Service credentials
-- `WIREGUARD_PORT`, `WIREGUARD_SUBNET`, `WIREGUARD_ALLOWEDIPS` - VPN configuration
-
-**Dashboard & Integration Variables:**
-- `TRANSPORT_NSW_API_KEY` - Transport NSW OpenData API key for real-time departures
-- `TRANSPORT_STOP_*` - Transit stop IDs and display names for dashboard widgets
-- `TOMTOM_API_KEY` - TomTom Traffic API key for traffic conditions
-- `TRAFFIC_ROUTE_*` - Traffic route configurations with origin/destination and schedules
-- `BOM_LOCATION` - Australian suburb name for Bureau of Meteorology weather
-- `GOOGLE_CALENDAR_ICAL_URL` - Google Calendar iCal URL for calendar widget
-
-**Bede AI Assistant Variables:**
-- `TELEGRAM_BOT_TOKEN` - Telegram bot token from @BotFather
-- `ALLOWED_USER_ID` - Your Telegram user ID (get from @userinfobot)
-- `VAULT_REPO` - Git repository URL for Obsidian vault (HTTPS with PAT or SSH)
-- `VAULT_SSH_KEY_PATH` - Host path to SSH private key for vault access (optional)
-- `SESSION_TIMEOUT_MINUTES` - Session continuity window (default: 10)
-- `GOOGLE_OAUTH_CLIENT_ID` - Google Cloud OAuth client ID for workspace-mcp
-- `GOOGLE_OAUTH_CLIENT_SECRET` - Google Cloud OAuth client secret for workspace-mcp
-
-See `.env.example` for complete variable list with descriptions and defaults.
-
-**Additional Environment Variables** (see `.env.example` for full documentation):
-- **Monitoring & Alerts:** `WEBHOOK_URL`, `ALERT_EMAIL_*` - AlertManager notification configuration
-- **n8n Performance:** `DB_SQLITE_POOL_SIZE`, `N8N_RUNNERS_*`, `EXECUTIONS_TIMEOUT*` - Performance tuning
-- **Dashboard:** `PUID`, `PGID`, `HOMEPAGE_ALLOWED_HOSTS` - Homepage permissions and access control
-- **Service Credentials:** Various `*_USERNAME` and `*_PASSWORD` pairs for service authentication
-- **WireGuard Advanced:** `WIREGUARD_SERVERURL` - Public IP for external VPN connections
-
-**Password Escaping**: Dollar signs in passwords must be escaped as `$$` for Docker Compose (e.g., `P@$$word123` → `P@$$$$word123`)
-
-## Docker Compose Labels Pattern
-
-Services use Traefik labels for automatic routing:
+### Traefik Labels for New Services
 ```yaml
 labels:
   - "traefik.enable=true"
   - "traefik.http.routers.<service>.rule=Host(`<service>.${DOMAIN}`)"
   - "traefik.http.routers.<service>.entrypoints=websecure"
   - "traefik.http.routers.<service>.tls=true"
-  - "traefik.http.routers.<service>.tls.certresolver=letsencrypt"
   - "traefik.http.services.<service>.loadbalancer.server.port=<internal-port>"
 ```
 
-For wildcard certificate (only on dashboard router):
-```yaml
-- "traefik.http.routers.dashboard.tls.domains[0].main=${DOMAIN}"
-- "traefik.http.routers.dashboard.tls.domains[0].sans=*.${DOMAIN}"
-```
+### Adding a New Service
+1. Add to appropriate compose file with Traefik labels
+2. Add env vars to `.env.example`
+3. Add to Homepage dashboard (`config/homepage/services-template.yaml`) with `showStats: true`
+4. Update `SERVICES.md`
+5. Test: `make validate && make start && make test-domain-access`
+
+### Environment Variables
+See `.env.example` for the complete variable list with descriptions. Dollar signs in passwords must be escaped as `$$` for Docker Compose.
 
 ## Git Workflow
 
-**Branching Strategy** (GitHub Flow):
-- `main` - production-ready code
-- Feature branches - `feature/description`, `fix/description`, `docs/description`
-- All changes via pull requests with reviews
-
-**Merge Strategy**:
-- Squash and merge for feature branches (default)
-- Create merge commit for releases
-
-## Scripts Overview
-
-### DNS & Domain Configuration
-- `scripts/adguard/setup-adguard-dns.sh` - Configures AdGuard DNS rewrites for `*.DOMAIN` → `SERVER_IP`
-  - Generates bcrypt password hash using htpasswd
-  - Creates/updates `AdGuardHome.yaml` with DNS rewrites
-  - Requires: `SERVER_IP`, `DOMAIN`, `ADGUARD_PASSWORD` in `.env`
-
-- `scripts/testing/test-domain-access.sh` - Tests HTTPS access to all services via domains
-
-### Service Configuration
-- `scripts/homepage/configure-homepage.sh` - Generates Homepage dashboard configuration files
-  - Creates `services.yaml`, `widgets.yaml`, `docker.yaml` from templates
-  - Substitutes environment variables in configuration
-  - Called during `make setup`
-
-- `scripts/traefik/setup-traefik-password.sh` - Generates Traefik dashboard password hash
-  - Reads `TRAEFIK_PASSWORD` from `.env`
-  - Creates htpasswd-format hash for basic authentication
-  - Sets `TRAEFIK_DASHBOARD_USERS` environment variable
-  - Called during `make setup`
-
-### SSL Certificate Management (certbot)
-- `scripts/ssl/setup-certbot-gandi.sh` - Installs certbot and generates Let's Encrypt wildcard certificate
-  - Installs certbot via snap and certbot-dns-gandi via pip3
-  - Handles Ubuntu 24.04 externally-managed Python environment (--break-system-packages)
-  - Creates Gandi API credentials file at `/etc/letsencrypt/gandi/gandi.ini`
-  - Generates wildcard cert for `*.DOMAIN` and `DOMAIN` using DNS-01 challenge
-  - Requires: `DOMAIN`, `LETSENCRYPT_EMAIL`, `GANDIV5_PERSONAL_ACCESS_TOKEN` in `.env`
-
-- `scripts/ssl/copy-certs-to-traefik.sh` - Copies certificates from Let's Encrypt to Traefik
-  - Copies `/etc/letsencrypt/live/DOMAIN/fullchain.pem` → `./data/traefik/certs/DOMAIN.crt`
-  - Copies `/etc/letsencrypt/live/DOMAIN/privkey.pem` → `./data/traefik/certs/DOMAIN.key`
-  - Sets proper ownership and permissions (644 for cert, 600 for key)
-
-- `scripts/traefik/configure-traefik-file-provider.sh` - Configures Traefik to use file provider
-  - Creates `./config/traefik/dynamic-certs.yml` with certificate paths
-  - Configures Traefik to load certificates from file instead of ACME
-  - Must restart Traefik after running (use `make restart` or `docker compose restart traefik`)
-
-- `scripts/ssl/setup-cert-renewal.sh` - Sets up automatic certificate renewal
-  - Creates post-renewal hook: `/etc/letsencrypt/renewal-hooks/deploy/traefik-reload.sh`
-  - Hook automatically copies renewed certs and restarts Traefik container
-  - Creates log file: `/var/log/certbot-traefik-reload.log`
-  - Tests renewal with dry run
-
-### VPN Management (System Service)
-- `make wireguard-install` (`scripts/wireguard/install-wireguard.sh`) - Installs WireGuard as system service (one-time setup)
-- `make wireguard-setup` (`scripts/wireguard/setup-wireguard-server.sh`) - Creates WireGuard server configuration
-- `sudo ./scripts/wireguard/wireguard-add-peer.sh <name>` - Adds VPN peers (clients) and generates client configs
-  - No make target — requires a peer name argument
-- `make wireguard-routing` (`scripts/wireguard/setup-wireguard-routing.sh`) - Configures iptables DOCKER-USER rules for VPN routing
-  - Detects primary LAN interface and Docker bridge subnet automatically
-  - Adds forwarding rules so VPN clients can reach Docker services and the LAN
-  - Installs `iptables-persistent` to survive reboots
-  - Run **after** `make start` (Docker networks must exist)
-  - Note: distinct from `wg0.conf` PostUp/PostDown rules — those handle VPN NAT, this handles Docker bridge forwarding
-- `make wireguard-test` (`scripts/wireguard/test-wireguard-routing.sh`) - Tests WireGuard routing configuration
-  - Verifies IP forwarding is enabled
-  - Checks NAT and DOCKER-USER iptables rules are configured
-  - Tests connectivity through VPN
-- `make wireguard-peers` (`scripts/wireguard/wireguard-peer-management.sh`) - Peer management utilities
-  - List all configured peers
-  - View peer statistics and connection status
-  - Remove or modify existing peers
-
-### System Setup (run manually once on a new machine — not called by any make target)
-- `scripts/system/install-docker-official.sh` - Installs Docker from official repository
-  - Removes snap-based Docker installation (snap Docker lacks docker group, breaks Homepage stats)
-  - Adds Docker's official apt repository and installs Docker CE
-  - Run: `./scripts/system/install-docker-official.sh`
-
-- `scripts/system/setup-user-permissions.sh` - Adds user to docker group
-  - Enables running docker commands without sudo
-  - Run: `./scripts/system/setup-user-permissions.sh`
-  - Requires logout/login to take effect
-
-- `scripts/system/setup-firewall.sh` - Configures UFW firewall rules
-  - Sets up default deny incoming, allow outgoing
-  - Allows SSH (rate-limited), HTTP/HTTPS, WireGuard
-  - Permits full access from local network and VPN subnet
-  - Run: `./scripts/system/setup-firewall.sh`
-
-## Monitoring Stack
-
-**Metrics Collection**:
-- Prometheus scrapes metrics every 15s from node-exporter (system) and cAdvisor (containers)
-- Grafana visualizes metrics with pre-configured dashboards
-- Alertmanager handles alert routing and notifications
-
-**Alert Configuration**:
-- Rules defined in `monitoring/prometheus/alert_rules.yml`
-- Alertmanager config in `monitoring/alertmanager/alertmanager.yml`
-- Alerts routed to webhook (default: `http://127.0.0.1:5001/`)
-
-**Accessing Monitoring**:
-- Grafana: `https://grafana.${DOMAIN}`
-- Prometheus: `https://prometheus.${DOMAIN}` (also direct: `http://${SERVER_IP}:9090`)
-- Alertmanager: `https://alerts.${DOMAIN}` (also direct: `http://${SERVER_IP}:9093`)
-
-## Service-Specific Notes
-
-### n8n
-- Workflow automation platform with SQLite database
-- Configured with Basic Auth: `N8N_USER` / `N8N_PASSWORD`
-- Webhook URL: `https://n8n.${DOMAIN}/webhook/*`
-- Environment variables include timeout settings and future compatibility flags
-- Init container ensures proper permissions (`n8n-init` service)
-
-### AdGuard Home
-- Dual access: Domain-based (`https://adguard.${DOMAIN}`) and direct IP (`http://${SERVER_IP}:8888`)
-- Configuration auto-generated by `setup-adguard-dns.sh` script
-- Requires bcrypt password hash (generated via htpasswd)
-- DNS rewrites configured as: `'*.${DOMAIN}' → ${SERVER_IP}`
-
-### Traefik
-- HTTP to HTTPS redirect configured on web entrypoint
-- Dashboard accessible at `https://traefik.${DOMAIN}` with basic auth
-- Debug logging enabled: `--log.level=DEBUG`
-- Health check via ping endpoint
-- **Certificate Management**: Uses file provider to load certbot-generated certificates
-  - File provider watches `/etc/traefik/` directory (mapped to `./config/traefik/`)
-  - Dynamic config: `./config/traefik/dynamic-certs.yml`
-  - Certificates loaded from `/certs/` (mapped to `./data/traefik/certs/`)
-
-### WireGuard (System Service)
-- **System-level service** (not Docker) for VPN access
-- Ensures VPN remains available when Docker services are restarted
-- Configuration: `/etc/wireguard/wg0.conf`
-- Peer configs: `./data/wireguard/peers/`
-- Split tunneling configured to route only home network and VPN subnet traffic
-- Auto-start enabled via systemd: `wg-quick@wg0`
-- Status check: `sudo wg show` or `make wireguard-status`
-
-### Homepage API (Custom Backend)
-- **Purpose:** Custom Flask backend providing integrations for Homepage dashboard
-- **Container:** `homepage-api` (built from `./homepage-api/`)
-- **Internal port:** 5000
-- **Domain access:** `https://homepage-api.${DOMAIN}`
-- **Security:** admin-secure middleware (IP whitelist + rate limiting)
-- **Features:**
-  - BOM (Bureau of Meteorology) weather data for Australian locations
-  - Transport NSW real-time departures API integration
-  - TomTom traffic conditions with schedule-based filtering
-  - WireGuard VPN system service monitoring (status, connected peers)
-  - Docker daemon system service monitoring (status, container count, disk usage)
-  - Health check endpoint at `/api/health`
-- **Configuration:**
-  - `BOM_LOCATION` - Australian suburb name for weather data
-  - `TRANSPORT_NSW_API_KEY` - Transport NSW API key
-  - `TRANSPORT_STOP_*` - Transit stop IDs and display names for dashboard widgets
-  - `TOMTOM_API_KEY` - TomTom API key for traffic data
-  - `TRAFFIC_ROUTE_*` - Multiple traffic routes with origin/destination/schedule
-  - `GOOGLE_CALENDAR_ICAL_URL` - Google Calendar iCal URL for calendar widget
-- **Why custom backend?**
-  - Homepage widget framework limited for complex API integrations
-  - Enables schedule-based filtering (e.g., show traffic only during commute hours)
-  - Centralizes API key management and rate limiting
-  - Provides caching layer to reduce external API calls
-  - Monitors system services (WireGuard, Docker) that aren't visible as containers
-- **Documentation:** See `homepage-api/README.md` for development and API endpoints
-
-### Homepage Dashboard
-- **Purpose:** Unified dashboard with system monitoring, service widgets, and custom integrations
-- **Image:** `ghcr.io/gethomepage/homepage:latest`
-- **Container:** `homepage`
-- **Internal port:** 3000
-- **Domain access:** `https://homepage.${DOMAIN}`
-- **Security:** admin-secure-no-ratelimit middleware (IP whitelist without rate limiting)
-- **Configuration:**
-  - Service definitions: `./data/homepage/config/services.yaml` (from template `./config/homepage/services-template.yaml`)
-  - Docker integration: mounts `/var/run/docker.sock` for container stats
-  - Widget APIs: Integrates with AdGuard, Grafana, Transport NSW, BOM, TomTom
-  - Environment templating: Uses `HOMEPAGE_VAR_*` env vars in configs
-- **Data persistence:** `./data/homepage/config/`
-- **Features:**
-  - System resource monitoring (CPU, RAM, network) for all containers
-  - Service health status and uptime
-  - Application-specific widgets (AdGuard stats, Grafana dashboards)
-  - Custom integrations via Homepage API backend
-  - Calendar integration (Google Calendar via iCal)
-- **Widget Architecture:**
-  - **Container stats** (showStats: true) - System resources from Docker
-  - **Application widgets** - App-specific metrics via APIs
-  - Both are complementary: container stats = infrastructure, widgets = application metrics
-- **Configuration:** See `config/homepage/services-template.yaml` for widget configuration
-
-## Documentation Structure
-
-Comprehensive docs in `docs/` directory:
-- `ARCHITECTURE.md` - Detailed system design and visual diagrams
-- `archive/SETUP.md` - Installation guide
-- `archive/CONFIGURATION.md` - Service configuration
-- `archive/OPERATIONS.md` - Day-to-day management, updates, backups
-- `archive/TROUBLESHOOTING.md` - Common issues and solutions
-- `archive/MONITORING_DEPLOYMENT.md` - Monitoring setup guide
-- `archive/ALERTS.md` - Alert definitions and response procedures
-- `archive/REMOTE_ACCESS.md` - VPN and port forwarding setup
-- `archive/BACKEND_API.md` - Homepage API backend documentation
-- `archive/DASHBOARD_SETUP.md` - Homepage dashboard setup guide
-
-Implementation roadmaps:
-- `tickets/monitoring-tickets/README.md` - Monitoring implementation roadmap
-- `tickets/security-tickets/README.md` - Security hardening roadmap (VPN-first strategy)
-
-## When Making Changes
-
-### Adding a New Service
-1. Add service definition to appropriate compose file
-2. Add Traefik labels for domain-based routing
-3. Add environment variables to `.env.example` with descriptive comments
-4. Update service list in `SERVICES.md`
-5. Add monitoring if needed (Prometheus scrape target)
-6. **IMPORTANT: Add to Homepage dashboard** (`config/homepage/services-template.yaml`):
-   - Include container stats for resource monitoring:
-     ```yaml
-     - Service Name:
-         icon: service-icon.png
-         href: https://service.{{HOMEPAGE_VAR_DOMAIN}}
-         description: Service description
-         container: container-name  # Must match container_name in docker-compose
-         server: my-docker          # References docker.yaml
-         showStats: true            # Enables CPU, memory, network stats
-     ```
-   - If service has an API widget, include both widget AND container stats
-   - Container stats show system resources (CPU, RAM, network)
-   - Widgets show application metrics (queries, users, etc.)
-   - Both are complementary, not redundant
-7. Update documentation (README.md, relevant docs/)
-8. Test: `make validate && make start && make test-domain-access`
-
-### Modifying Environment Variables
-1. Update `.env.example` with new/changed variables and comments
-2. Update documentation mentioning those variables
-3. Ensure backwards compatibility or document breaking changes
-4. If adding secrets, ensure pre-commit hooks catch them (`.pre-commit-config.yaml`)
-
-### Modifying Docker Compose
-1. Always run `make validate` before committing
-2. Test service starts correctly: `make start && make status`
-3. Check logs for errors: `make logs`
-4. Verify service accessibility via domain
-
-### Modifying Scripts
-1. Test script locally first
-2. Ensure proper error handling (`set -e`)
-3. Add helpful output with colors (see `setup-adguard-dns.sh` for example)
-4. Update Makefile if script should be called via make target
-
-## Common Issues
-
-### SSL Certificate Issues
-
-**Quick diagnostics:**
-```bash
-# Check certificates exist
-ls -la ./data/traefik/certs/
-
-# Verify Traefik loaded certs
-docker compose logs traefik | grep -i certificate
-
-# View Let's Encrypt certificate status
-sudo certbot certificates
-
-# Check renewal hook logs
-sudo tail -20 /var/log/certbot-traefik-reload.log
-```
-
-**Common fixes:**
-- Browser caching old cert: Clear cache or Cmd+Shift+R (Safari especially prone)
-- File provider not loaded: Check `./config/traefik/dynamic-certs.yml` exists
-- Permissions wrong: Cert should be 644, key should be 600
-- After config changes: Must recreate container with `docker compose up -d --force-recreate traefik`
-
-### DNS Resolution
-- Ensure AdGuard is running: `docker compose ps adguard`
-- Test DNS directly: `dig @${SERVER_IP} n8n.${DOMAIN} +short`
-- Check AdGuard logs: `docker compose logs adguard`
-- Verify DNS rewrites: `./scripts/adguard/setup-adguard-dns.sh`
-
-### Service Not Accessible
-1. Check service is running: `make status`
-2. Check Traefik routing: `docker compose logs traefik | grep <service-name>`
-3. Verify DNS resolves to SERVER_IP: `dig @${SERVER_IP} <service>.${DOMAIN}`
-4. Test direct port access (if exposed): `curl http://${SERVER_IP}:<port>`
-
-## Security Considerations
-
-- **Never commit** `.env` files or secrets
-- Pre-commit hooks scan for secrets (`.pre-commit-config.yaml`)
-- All passwords must be changed from defaults in `.env.example`
-- Docker images should be pinned versions (not `:latest` in production)
-- VPN-first: Only WireGuard should be exposed to internet by default
-- See `security-tickets/README.md` for complete security roadmap
+GitHub Flow: `main` is production. Feature branches (`feature/`, `fix/`, `docs/`). PRs with squash merge.
 
 ## Testing Checklist
 
-Before submitting changes:
-- [ ] `make validate` passes
-- [ ] `make start` successfully starts all services
-- [ ] `make status` shows all services as healthy
-- [ ] `make logs` shows no errors
-- [ ] `make test-domain-access` passes (if domain routing affected)
-- [ ] Documentation updated for user-facing changes
-- [ ] `.env.example` updated if new variables added
-- [ ] No secrets committed (pre-commit hooks pass)
+Before submitting: `make validate` passes, services start healthy, no log errors, domain access works, `.env.example` updated for new vars, no secrets committed.

--- a/docs/security-audit-2026-04-17.md
+++ b/docs/security-audit-2026-04-17.md
@@ -1,0 +1,84 @@
+# Security Audit — 2026-04-17
+
+Audit of the home-server-stack repo, grouped by severity. File:line references point to state at the time of the audit.
+
+## Critical
+
+### 1. No `detect-secrets` safety net for `.env`
+The live `.env` contains real credentials (Telegram bot token, Gandi PAT, service passwords, API keys). `.gitignore` blocks it today, but a bad `git add -A` or a misconfigured hook would leak everything.
+- **Fix:** add `detect-secrets` (or equivalent) to `.pre-commit-config.yaml` as a defence-in-depth layer.
+
+## High
+
+### 2. `N8N_BLOCK_ENV_ACCESS_IN_NODE=false`
+`.env:48` — n8n workflow code can read every host env var, including all passwords and API tokens. If the n8n UI is ever accidentally exposed, an attacker with workflow-edit rights exfiltrates everything.
+- **Fix:** set `N8N_BLOCK_ENV_ACCESS_IN_NODE=true` and pass secrets explicitly through n8n credentials.
+
+### 3. cAdvisor runs `privileged: true`
+`docker-compose.monitoring.yml:93-109` — privileged mode + mounts on `/`, `/sys`, `/var/run`. A cAdvisor compromise → host root. cAdvisor is also no longer actively maintained upstream.
+- **Fix:** drop `privileged`, mount only the paths cAdvisor actually needs, or remove cAdvisor entirely (node-exporter + Prometheus cover most metrics).
+
+### 4. Fail2ban with `network_mode: host` + `NET_ADMIN`/`NET_RAW`
+`docker-compose.network.yml:274-292` — fail2ban parses Traefik logs with full iptables control. A log-injection exploit against a sloppy `failregex` can execute arbitrary actions.
+- **Fix:** audit every filter in `config/fail2ban/filter.d/` for unsafe regex and shell metacharacters in actions. Consider running fail2ban in its own network namespace.
+
+### 5. Docker socket mounted into homepage + homepage-api
+`docker-compose.dashboard.yml:30,84` — even `:ro`, the Docker API exposes full cluster topology and enables reconnaissance. Combined with a Flask/Homepage RCE, this is a cluster-wide foothold.
+- **Fix:** insert a `tecnativa/docker-socket-proxy` sidecar that exposes only the container/stats endpoints homepage actually needs.
+
+## Medium
+
+### 6. `:latest` image tags across production services
+Prometheus, Grafana, Alertmanager, AdGuard, n8n, Homepage, Fail2ban all use `:latest`. `docker compose pull` can silently upgrade to breaking or regressed versions.
+- **Fix:** pin versions and enable Renovate or Dependabot for controlled updates.
+
+### 7. Prometheus + Alertmanager bound directly on `SERVER_IP`
+`docker-compose.monitoring.yml:7,60` — `9090` and `9093` are published on the LAN IP, bypassing Traefik's admin-secure middleware for anyone on the local network or on a VPN client that reaches those ports.
+- **Fix:** remove the `ports:` blocks, use `expose:`, and access only via `prometheus.${DOMAIN}` / `alerts.${DOMAIN}`.
+
+### 8. Unrestricted CORS on homepage-api
+`homepage-api/app.py:20` — `CORS(app)` allows every origin.
+- **Fix:** `CORS(app, origins=[f"https://homepage.{DOMAIN}"], credentials=True)`.
+
+### 9. No secret rotation policy
+Gandi PAT, Telegram bot token, Transport NSW, TomTom, Google OAuth — all long-lived with no documented rotation cadence.
+- **Fix:** document a rotation schedule (e.g. Gandi PAT every 6 months, bot token quarterly) and record the procedure.
+
+### 10. TomTom geocoding has no input bounds
+`homepage-api/app.py:388-408` — URL-encoded but not length-capped or region-restricted.
+- **Fix:** cap input length, whitelist Australian bounding box, rate-limit per unique origin/destination pair.
+
+## Low
+
+### 11. No `read_only: true` on containers
+A compromised service can drop persistence artefacts on its rootfs.
+- **Fix:** add `read_only: true` + `tmpfs: ["/tmp", "/run"]` where state is runtime-only.
+
+### 12. No resource limits
+No `deploy.resources.limits` on any service — one runaway process can DoS the host.
+- **Fix:** add `cpus` and `memory` limits/reservations per service.
+
+### 13. No Docker log rotation
+- **Fix:** set `log-driver: json-file` with `max-size: 10m, max-file: 3` in each service or daemon-wide.
+
+### 14. Fail2ban filter rules not reviewed for ReDoS
+Catastrophic backtracking in `failregex` could be weaponised via crafted log lines.
+- **Fix:** run regex rules through a ReDoS linter, or restrict to known-good community rules.
+
+## Positive observations
+
+- Every Traefik router has explicit `admin-secure` or `dashboard-secure` middleware — no accidental exposures.
+- IP whitelist (RFC1918 + VPN subnet) + rate limiting + HSTS preload on admin routes.
+- Bede Telegram handlers all check `ALLOWED_USER_ID` before processing commands.
+- data-ingest and data-mcp use parameterised SQLite queries throughout — no SQLi.
+- Bede subprocess calls use list args, no `shell=True`.
+- UFW default-deny incoming + WireGuard split tunnelling (no `0.0.0.0/0`).
+- Traefik v3.6.2 (patched), not the old 3.2 line with the Gandi/Lego issues.
+
+## Top 5 to fix first
+
+1. Add `detect-secrets` pre-commit hook.
+2. `N8N_BLOCK_ENV_ACCESS_IN_NODE=true`.
+3. Remove direct `SERVER_IP:9090` / `:9093` binds; route only through Traefik.
+4. Pin all `:latest` images and enable Renovate/Dependabot.
+5. Replace raw docker.sock mounts with a socket-proxy sidecar.


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Simplified from 744 → 100 lines. Removed script-by-script docs, exhaustive env var lists, service-specific notes, and troubleshooting guides that Claude can derive from reading the actual files. Kept architectural decisions, dev environment constraints, make targets, and change patterns.
- **.gitignore**: Added `CLAUDE.local.md` (for local cross-project context that shouldn't be committed). Removed `bede/CLAUDE.md` entry (file deleted, deployment-only).
- **Security audit** (`docs/security-audit-2026-04-17.md`): Full audit from 2026-04-17 covering 14 findings across critical/high/medium/low severity, plus positive observations. Unrelated to the CLAUDE.md changes but included here to avoid a single-file PR.

## Test plan
- [ ] Verify `CLAUDE.local.md` does not appear in `git status`
- [ ] Spot-check that key CLAUDE.md sections survived (dev environment warning, make targets, architecture, patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)