### PR TITLE
fix: remove workspace-mcp from homepage after bede consolidation

### DIFF
--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -244,14 +244,7 @@
   - AI Services:
       - Bede:
           icon: mdi-robot
-          description: Personal AI assistant (Telegram)
+          description: Personal AI assistant with data & workspace services
           container: bede
-          server: my-docker
-          showStats: true
-
-      - Workspace MCP:
-          icon: mdi-google
-          description: Google Workspace MCP server
-          container: workspace-mcp
           server: my-docker
           showStats: true


### PR DESCRIPTION
## Summary
- Remove stale `Workspace MCP` entry from Homepage dashboard — it's no longer a separate container
- Update Bede's description to reflect it now bundles data-ingest, data-mcp, and workspace-mcp

Follows up on the bede standalone image refactor (`refactor/bede-standalone-image`).

## Test plan
- [ ] `make validate` passes
- [ ] Homepage dashboard loads without errors after deploy
- [ ] Bede entry shows updated description and container stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)