### PR TITLE
fix: add USER_GOOGLE_EMAIL env var and increase session timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -267,6 +267,11 @@ GOOGLE_OAUTH_CLIENT_SECRET=your_google_oauth_client_secret_here
 # Redirect URI is https://mcp.${DOMAIN}/oauth2callback — set this exact value
 # as an authorised redirect URI in Google Cloud Console (Web application type).
 
+# Google account email for workspace-mcp tools (Calendar, Gmail, Tasks).
+# Must match the account you authenticate during OAuth setup.
+# workspace-mcp uses this as the default when Claude omits the email parameter.
+USER_GOOGLE_EMAIL=your-google-account@gmail.com
+
 # -----------------------------------------------------------------------------
 # Data Ingest (data-ingest — receives health + vault data, writes to SQLite)
 # Replaces hae-server + vault CSV git pipeline.

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -6,7 +6,7 @@ services:
     env_file: .env
     environment:
       - CLAUDE_WORKDIR=/app
-      - SESSION_TIMEOUT_MINUTES=10
+      - SESSION_TIMEOUT_MINUTES=120
       - ANTHROPIC_API_KEY=
       - SQLITE_DB_PATH=/data/sqlite/bede.db
       - INGEST_URL=http://localhost:8001/ingest/vault
@@ -22,6 +22,7 @@ services:
       - WORKSPACE_MCP_OAUTH_PROXY_STORAGE_BACKEND=disk
       - WORKSPACE_MCP_OAUTH_PROXY_DISK_DIRECTORY=/data/workspace-mcp/oauth-proxy
       - MCP_SINGLE_USER_MODE=true
+      - USER_GOOGLE_EMAIL=${USER_GOOGLE_EMAIL}
     volumes:
       # Persona file (personal, not committed — copy from CLAUDE.md.example in bede repo)
       - ./data/bede/CLAUDE.md:/app/CLAUDE.md:ro


### PR DESCRIPTION
## Summary
- Adds `USER_GOOGLE_EMAIL` passthrough in `docker-compose.ai.yml` so workspace-mcp defaults to the correct Google account in single-user mode
- Adds `USER_GOOGLE_EMAIL` to `.env.example` with documentation
- Increases `SESSION_TIMEOUT_MINUTES` from 10 to 120

## Context
Sunday Scout and other scheduled tasks were calling workspace-mcp Google tools with `joeradford@gmail.com` (inferred by Claude from the user's name) instead of `ai.joeradford@gmail.com` (the actual authenticated account). The `USER_GOOGLE_EMAIL` env var tells workspace-mcp which account to use when Claude omits the email parameter.

Companion PR: josephradford/bede#5

## Test plan
- [ ] `make validate` passes
- [ ] `USER_GOOGLE_EMAIL` is set in server `.env`
- [ ] After `docker compose up -d bede`, verify: `docker exec bede env | grep USER_GOOGLE_EMAIL`
- [ ] Trigger a task that uses workspace-mcp and confirm it uses `ai.joeradford@gmail.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)