### PR TITLE
docs: update CLAUDE.md for Bede GHCR deploy workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Self-hosted Docker Compose infrastructure stack: home automation, workflow autom
 | `make purge` | **DESTRUCTIVE** — removes everything including ./data/ |
 
 **Bede AI services** (also included in main targets):
-`make bede-start` / `bede-stop` / `bede-restart` / `bede-build` / `bede-status`
+`make bede-start` / `bede-stop` / `bede-restart` / `bede-pull` / `bede-status`
 
 **SSL**: `make ssl-setup` / `ssl-renew-test`
 
@@ -45,7 +45,7 @@ Add peers: `sudo ./scripts/wireguard/wireguard-add-peer.sh <name>`
 - `docker-compose.network.yml` — Network & security (Traefik, Fail2ban)
 - `docker-compose.monitoring.yml` — Monitoring (Prometheus, Grafana, Alertmanager, exporters)
 - `docker-compose.dashboard.yml` — Dashboard (Homepage, Homepage API)
-- `docker-compose.ai.yml` — AI services (Bede, workspace-mcp, data-mcp, data-ingest)
+- `docker-compose.ai.yml` — AI services (Bede — prebuilt GHCR image from josephradford/bede)
 
 The Makefile combines all five files by default.
 
@@ -94,6 +94,14 @@ See `.env.example` for the complete variable list with descriptions. Dollar sign
 ## Git Workflow
 
 GitHub Flow: `main` is production. Feature branches (`feature/`, `fix/`, `docs/`). PRs with squash merge.
+
+### Deploying Bede changes
+
+Bede source lives in a separate repo (josephradford/bede). The deploy workflow is:
+
+1. Make changes in the bede repo, create a PR, merge to main
+2. **Wait for GitHub Actions to build and push the new GHCR image** — do not deploy until the build completes
+3. On the server: `make bede-pull && make bede-restart`
 
 ## Testing Checklist
 


### PR DESCRIPTION
## Summary
- Replaces `bede-build` with `bede-pull` in make targets (Bede now uses prebuilt GHCR image, not local build)
- Updates AI services description to reflect the consolidated single-container Bede architecture
- Adds "Deploying Bede changes" section documenting the required workflow: PR → merge → wait for GitHub Actions GHCR build → pull + restart on server

## Test plan
- [ ] Review CLAUDE.md content is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)