### PR TITLE
fix: replace UFW SSH rate limit with system fail2ban

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ help:
 	@echo "  ./scripts/system/install-docker-official.sh       - Replace snap Docker with official Docker CE"
 	@echo "  ./scripts/system/setup-user-permissions.sh        - Add user to docker group (requires logout)"
 	@echo "  ./scripts/system/setup-firewall.sh               - Configure UFW firewall rules"
+	@echo "  ./scripts/system/setup-fail2ban.sh               - Install system fail2ban for SSH protection"
 	@echo ""
 	@echo "Setup & Deployment:"
 	@echo "  make setup              - First time setup (core + monitoring + dashboard)"

--- a/scripts/system/setup-fail2ban.sh
+++ b/scripts/system/setup-fail2ban.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}System Fail2ban Setup for SSH Protection${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo "This installs system-level fail2ban for SSH brute-force protection."
+echo "It replaces UFW's hardcoded rate limit with a configurable jail that"
+echo "ignores local network and VPN subnets."
+echo ""
+
+# Load environment variables for subnet config
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+WIREGUARD_SUBNET="${WIREGUARD_SUBNET:-10.13.13.0/24}"
+
+echo -e "${GREEN}Step 1/4: Installing fail2ban...${NC}"
+if ! command -v fail2ban-client &> /dev/null; then
+    sudo apt-get update -qq
+    sudo apt-get install -y fail2ban
+    echo -e "${GREEN}✓ fail2ban installed${NC}"
+else
+    echo -e "${GREEN}✓ fail2ban already installed${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}Step 2/4: Removing UFW SSH rate limit (fail2ban takes over)...${NC}"
+if sudo ufw status | grep -q 'LIMIT'; then
+    sudo ufw delete limit ssh/tcp 2>/dev/null || true
+    echo -e "${GREEN}✓ UFW SSH rate limit removed${NC}"
+else
+    echo -e "${GREEN}✓ No UFW SSH rate limit to remove${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}Step 3/4: Configuring sshd jail...${NC}"
+sudo tee /etc/fail2ban/jail.local > /dev/null <<EOF
+[DEFAULT]
+bantime = 1h
+findtime = 10m
+maxretry = 5
+ignoreip = 127.0.0.1/8 192.168.0.0/16 10.0.0.0/8 172.16.0.0/12
+
+[sshd]
+enabled = true
+port = ssh
+filter = sshd
+logpath = /var/log/auth.log
+maxretry = 10
+findtime = 5m
+bantime = 30m
+EOF
+echo -e "${GREEN}✓ /etc/fail2ban/jail.local written${NC}"
+echo "  sshd jail: 10 failed attempts in 5 minutes → 30 minute ban"
+echo "  Ignored: localhost, RFC1918 (local net), WireGuard subnet"
+
+echo ""
+echo -e "${GREEN}Step 4/4: Enabling and starting fail2ban...${NC}"
+sudo systemctl enable fail2ban
+sudo systemctl restart fail2ban
+
+echo ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}✓ System fail2ban configured!${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+sudo fail2ban-client status sshd
+echo ""
+echo -e "${YELLOW}Useful commands:${NC}"
+echo "  sudo fail2ban-client status sshd        # Check jail status"
+echo "  sudo fail2ban-client set sshd unbanip IP # Unban an IP"
+echo "  sudo fail2ban-client get sshd maxretry   # Check threshold"

--- a/scripts/system/setup-firewall.sh
+++ b/scripts/system/setup-firewall.sh
@@ -58,7 +58,9 @@ sudo ufw default allow outgoing
 echo ""
 echo -e "${GREEN}Step 2/7: Allowing SSH (port 22)...${NC}"
 sudo ufw allow 22/tcp comment 'SSH'
-sudo ufw limit ssh/tcp comment 'SSH rate limiting'
+# SSH brute-force protection handled by system fail2ban (setup-fail2ban.sh)
+# which supports ignoreip for local/VPN subnets. UFW limit is too blunt
+# (hardcoded 6 conns/30s, no whitelist).
 
 echo ""
 echo -e "${GREEN}Step 3/7: Allowing WireGuard VPN (port ${WIREGUARD_PORT})...${NC}"
@@ -90,7 +92,7 @@ echo -e "${GREEN}Current UFW Status:${NC}"
 sudo ufw status verbose
 echo ""
 echo -e "${YELLOW}Security Notes:${NC}"
-echo "  • SSH access is rate-limited to prevent brute force"
+echo "  • SSH brute-force protection via system fail2ban (run setup-fail2ban.sh)"
 echo "  • Only WireGuard (UDP ${WIREGUARD_PORT}) is exposed to the internet"
 echo "  • HTTP/HTTPS (80/443) are open for Traefik reverse proxy"
 echo "  • Local network and VPN clients have full access"


### PR DESCRIPTION
## Summary
- UFW `limit` is hardcoded at 6 connections/30s with no IP whitelist — blocks legitimate rapid SSH sessions from trusted IPs
- Add `scripts/system/setup-fail2ban.sh` that installs system-level fail2ban with a configurable sshd jail (10 failed auths in 5 min → 30 min ban)
- Local network (`192.168.0.0/16`) and VPN (`10.0.0.0/8`) subnets whitelisted via `ignoreip` — successful connections never count
- Remove `ufw limit ssh/tcp` from firewall setup script (fail2ban takes over SSH protection)

## Test plan
- [ ] Deploy to server, run `sudo ./scripts/system/setup-fail2ban.sh`
- [ ] Re-run `sudo ./scripts/system/setup-firewall.sh` to drop the UFW LIMIT rule
- [ ] Verify `sudo ufw status` shows SSH as ALLOW (not LIMIT)
- [ ] Verify `sudo fail2ban-client status sshd` shows jail active
- [ ] Rapid SSH sessions from local network no longer get blocked
- [ ] Failed SSH auth from a non-whitelisted IP still gets banned after 10 attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)