### PR TITLE
feat: add bede-deploy and bede-scout-config dev skills

### DIFF
--- a/.claude/skills/bede-deploy/SKILL.md
+++ b/.claude/skills/bede-deploy/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: bede-deploy
+description: >
+  Commit, PR, merge, wait for GHCR build, and deploy Bede changes to the
+  server. Use when changes have been made in the bede repo and need to be
+  shipped.
+---
+
+# Bede Deploy Skill
+
+End-to-end deployment of bede repo changes to the home server.
+
+## Prerequisites
+
+Read `.claude/server-test.local` in the home-server-stack project root to get
+`SERVER_USER` and `SERVER_HOST`. If missing, tell the user to create it from
+the template.
+
+## Step 1 — Check bede repo state
+
+```bash
+git -C /Users/joeradford/dev/bede status
+git -C /Users/joeradford/dev/bede log --oneline -5
+git -C /Users/joeradford/dev/bede diff --stat
+```
+
+If there are uncommitted changes, ask the user if they want to commit them.
+If there are no changes and HEAD is already on main with nothing ahead of
+origin, tell the user there's nothing to deploy.
+
+## Step 2 — Create branch and commit (if needed)
+
+If on `main` with uncommitted changes, create a feature branch:
+```bash
+git -C /Users/joeradford/dev/bede checkout -b feat/<descriptive-name>
+```
+
+Stage and commit the changes. Follow the repo's commit style.
+
+## Step 3 — Push and create PR
+
+```bash
+git -C /Users/joeradford/dev/bede push -u origin <branch>
+```
+
+Create a PR using `gh pr create --repo josephradford/bede`. Include a summary
+of what changed and a test plan.
+
+## Step 4 — Merge the PR
+
+Ask the user for confirmation before merging. Then:
+```bash
+gh pr merge <number> --repo josephradford/bede --squash --delete-branch
+```
+
+## Step 5 — Wait for GHCR image build
+
+Check the GitHub Actions build status:
+```bash
+gh run list --repo josephradford/bede --limit 1 --json status,conclusion,headSha
+```
+
+Poll every 30 seconds until the build completes. If it fails, show the logs
+and stop.
+
+## Step 6 — Deploy to server
+
+```bash
+ssh ${SERVER_USER}@${SERVER_HOST} "cd ~/home-server-stack && make bede-pull && make bede-restart"
+```
+
+## Step 7 — Verify
+
+```bash
+ssh ${SERVER_USER}@${SERVER_HOST} "cd ~/home-server-stack && make bede-status"
+```
+
+Confirm Bede is running and the container was created within the last few
+minutes (indicating the new image was pulled).
+
+Report the full pipeline result: commit SHA, PR number, build status,
+container status.

--- a/.claude/skills/bede-deploy/SKILL.md
+++ b/.claude/skills/bede-deploy/SKILL.md
@@ -2,32 +2,37 @@
 name: bede-deploy
 description: >
   Commit, PR, merge, wait for GHCR build, and deploy Bede changes to the
-  server. Use whenever changes have been made in the bede repo
-  (/Users/joeradford/dev/bede) and need to be shipped — including "deploy
-  bede", "ship the bot changes", "push bede to the server", or any request
-  to get bede repo code onto production.
+  server. Use whenever changes have been made in the bede repo and need to
+  be shipped — including "deploy bede", "ship the bot changes", "push bede
+  to the server", or any request to get bede repo code onto production.
 ---
 
 # Bede Deploy Skill
 
 End-to-end deployment of bede repo changes to the home server.
 
-The bede repo lives at `/Users/joeradford/dev/bede`. The GitHub remote is
-`josephradford/bede`. The server deploys from GHCR images built by GitHub
-Actions on merge to main.
+Read CLAUDE.local.md to find the bede repo path. The GitHub remote is
+referenced in the repo's git config. The server deploys from GHCR images
+built by GitHub Actions on merge to main.
 
 ## Prerequisites
 
-Read `.claude/server-test.local` in the home-server-stack project root to get
-`SERVER_USER` and `SERVER_HOST`. If missing, tell the user to create it from
-the template.
+- Read CLAUDE.local.md for the bede repo path (referred to as `BEDE_REPO`
+  below)
+- Read `.claude/server-test.local` in the home-server-stack project root to
+  get `SERVER_USER` and `SERVER_HOST`. If missing, tell the user to create it
+  from the template.
+- Determine the GitHub owner/repo from the bede repo's git remote:
+  ```bash
+  git -C $BEDE_REPO remote get-url origin
+  ```
 
 ## Step 1 — Check bede repo state
 
 ```bash
-git -C /Users/joeradford/dev/bede status
-git -C /Users/joeradford/dev/bede log --oneline -5
-git -C /Users/joeradford/dev/bede diff --stat
+git -C $BEDE_REPO status
+git -C $BEDE_REPO log --oneline -5
+git -C $BEDE_REPO diff --stat
 ```
 
 Determine the current situation:
@@ -44,32 +49,32 @@ commits: `feat:`, `fix:`, `docs:`).
 ## Step 3 — Push and create PR
 
 ```bash
-git -C /Users/joeradford/dev/bede push -u origin <branch>
+git -C $BEDE_REPO push -u origin <branch>
 ```
 
 Check for an existing PR first:
 ```bash
-gh pr list --repo josephradford/bede --head <branch>
+gh pr list --repo <owner/repo> --head <branch>
 ```
 
 If a PR already exists, show it and ask if the user wants to update it or
 merge it. If no PR exists, create one:
 ```bash
-gh pr create --repo josephradford/bede --title "<title>" --body "<body>"
+gh pr create --repo <owner/repo> --title "<title>" --body "<body>"
 ```
 
 ## Step 4 — Merge the PR
 
 Ask the user for confirmation before merging. Then:
 ```bash
-gh pr merge <number> --repo josephradford/bede --squash --delete-branch
+gh pr merge <number> --repo <owner/repo> --squash --delete-branch
 ```
 
 ## Step 5 — Wait for GHCR image build
 
 Use `gh run watch` which blocks until the run completes:
 ```bash
-gh run watch --repo josephradford/bede $(gh run list --repo josephradford/bede --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch --repo <owner/repo> $(gh run list --repo <owner/repo> --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
 
 If the build fails, show the logs and stop.

--- a/.claude/skills/bede-deploy/SKILL.md
+++ b/.claude/skills/bede-deploy/SKILL.md
@@ -2,13 +2,19 @@
 name: bede-deploy
 description: >
   Commit, PR, merge, wait for GHCR build, and deploy Bede changes to the
-  server. Use when changes have been made in the bede repo and need to be
-  shipped.
+  server. Use whenever changes have been made in the bede repo
+  (/Users/joeradford/dev/bede) and need to be shipped — including "deploy
+  bede", "ship the bot changes", "push bede to the server", or any request
+  to get bede repo code onto production.
 ---
 
 # Bede Deploy Skill
 
 End-to-end deployment of bede repo changes to the home server.
+
+The bede repo lives at `/Users/joeradford/dev/bede`. The GitHub remote is
+`josephradford/bede`. The server deploys from GHCR images built by GitHub
+Actions on merge to main.
 
 ## Prerequisites
 
@@ -24,18 +30,16 @@ git -C /Users/joeradford/dev/bede log --oneline -5
 git -C /Users/joeradford/dev/bede diff --stat
 ```
 
-If there are uncommitted changes, ask the user if they want to commit them.
-If there are no changes and HEAD is already on main with nothing ahead of
-origin, tell the user there's nothing to deploy.
+Determine the current situation:
+- **On main, no changes:** nothing to deploy — tell the user.
+- **On main, uncommitted changes:** create a feature branch, then commit.
+- **On a feature branch, uncommitted changes:** commit to the current branch.
+- **On a feature branch, clean:** check if there's already a PR open for it.
 
-## Step 2 — Create branch and commit (if needed)
+## Step 2 — Commit (if needed)
 
-If on `main` with uncommitted changes, create a feature branch:
-```bash
-git -C /Users/joeradford/dev/bede checkout -b feat/<descriptive-name>
-```
-
-Stage and commit the changes. Follow the repo's commit style.
+Stage and commit the changes. Follow the repo's commit style (conventional
+commits: `feat:`, `fix:`, `docs:`).
 
 ## Step 3 — Push and create PR
 
@@ -43,8 +47,16 @@ Stage and commit the changes. Follow the repo's commit style.
 git -C /Users/joeradford/dev/bede push -u origin <branch>
 ```
 
-Create a PR using `gh pr create --repo josephradford/bede`. Include a summary
-of what changed and a test plan.
+Check for an existing PR first:
+```bash
+gh pr list --repo josephradford/bede --head <branch>
+```
+
+If a PR already exists, show it and ask if the user wants to update it or
+merge it. If no PR exists, create one:
+```bash
+gh pr create --repo josephradford/bede --title "<title>" --body "<body>"
+```
 
 ## Step 4 — Merge the PR
 
@@ -55,13 +67,12 @@ gh pr merge <number> --repo josephradford/bede --squash --delete-branch
 
 ## Step 5 — Wait for GHCR image build
 
-Check the GitHub Actions build status:
+Use `gh run watch` which blocks until the run completes:
 ```bash
-gh run list --repo josephradford/bede --limit 1 --json status,conclusion,headSha
+gh run watch --repo josephradford/bede $(gh run list --repo josephradford/bede --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
 
-Poll every 30 seconds until the build completes. If it fails, show the logs
-and stop.
+If the build fails, show the logs and stop.
 
 ## Step 6 — Deploy to server
 

--- a/.claude/skills/bede-scout-config/SKILL.md
+++ b/.claude/skills/bede-scout-config/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: bede-scout-config
+description: >
+  Add, remove, or update tracked items in Bede's Deal Scout preference files
+  (clothing, camping gear, groceries, vacuum, events). Use when the user wants
+  to track a new product, change a deal threshold, or remove something from
+  the scout.
+---
+
+# Bede Scout Config Skill
+
+Manage the preference files that drive Bede's Deal Scout.
+
+## Preference files
+
+All files live in the Obsidian vault at:
+`/Users/joeradford/Library/Mobile Documents/iCloud~md~obsidian/Documents/JoeVault/Bede/`
+
+| File | Scout category |
+|------|---------------|
+| `staples.md` | Groceries |
+| `vacuum-preferences.md` | Vacuum |
+| `clothing-preferences.md` | Clothing |
+| `camping-gear.md` | Camping Gear |
+| `event-preferences.md` | Events |
+
+## Step 1 — Identify the category
+
+From the user's request, determine which preference file to edit. If unclear,
+ask.
+
+## Step 2 — Read the file
+
+Read the target preference file to understand the existing format: table
+structure, column names, how items are listed, and what thresholds look like.
+
+## Step 3 — Apply the change
+
+Match the existing format exactly. For each item type, ensure:
+
+**Clothing:** Item name, size, and notes (e.g. price threshold, style filter).
+Add retailer URLs if the user provides them.
+
+**Groceries:** Item name, brand, size, and deal threshold.
+
+**Camping gear:** Product name, retailer URLs, and target price.
+
+**Vacuum:** Model, target price, and retailer notes.
+
+**Events:** Artist/category, venue preferences, and source URLs.
+
+## Step 4 — Confirm
+
+Show the user the change you made (the specific lines added/modified) and
+which file was updated. Remind them the vault will sync to the server
+automatically.
+
+## Rules
+
+- Never remove items unless the user explicitly asks
+- Preserve the existing table/list format — don't restructure the file
+- Include price thresholds when the user provides them
+- If the user gives a retailer URL, add it to the trusted retailers section
+- If adding a new category of item that doesn't fit any existing file, ask
+  rather than creating a new file

--- a/.claude/skills/bede-scout-config/SKILL.md
+++ b/.claude/skills/bede-scout-config/SKILL.md
@@ -14,8 +14,8 @@ Manage the preference files that drive Bede's Deal Scout.
 
 ## Preference files
 
-All files live in the Obsidian vault at:
-`/Users/joeradford/Library/Mobile Documents/iCloud~md~obsidian/Documents/JoeVault/Bede/`
+Read CLAUDE.local.md for the Obsidian vault path. The preference files live
+in the `Bede/` subdirectory of the vault:
 
 | File | Scout category |
 |------|---------------|

--- a/.claude/skills/bede-scout-config/SKILL.md
+++ b/.claude/skills/bede-scout-config/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Add, remove, or update tracked items in Bede's Deal Scout preference files
   (clothing, camping gear, groceries, vacuum, events). Use when the user wants
   to track a new product, change a deal threshold, or remove something from
-  the scout.
+  the scout. Also triggers for "add X to the scout", "stop tracking Y", or
+  "change the price target for Z".
 ---
 
 # Bede Scout Config Skill
@@ -23,6 +24,10 @@ All files live in the Obsidian vault at:
 | `clothing-preferences.md` | Clothing |
 | `camping-gear.md` | Camping Gear |
 | `event-preferences.md` | Events |
+
+Search methodology and shared rules are in `scout-rules.md` — read it if the
+user's request involves how items are searched (e.g. which sites to check,
+stock verification rules).
 
 ## Step 1 — Identify the category
 
@@ -52,8 +57,8 @@ Add retailer URLs if the user provides them.
 ## Step 4 — Confirm
 
 Show the user the change you made (the specific lines added/modified) and
-which file was updated. Remind them the vault will sync to the server
-automatically.
+which file was updated. The vault syncs to the server via the
+obsidian-git-backup launchd job every 2 minutes when the MacBook is open.
 
 ## Rules
 

--- a/CLAUDE.local.md.example
+++ b/CLAUDE.local.md.example
@@ -1,0 +1,43 @@
+# CLAUDE.local.md
+
+Cross-project context for working across your ecosystem from within home-server-stack. These paths are machine-specific and must not be committed.
+
+Copy this file to `CLAUDE.local.md` and fill in your paths.
+
+## Paths
+
+| Name | Path |
+|------|------|
+| Bede repo | `/path/to/bede` |
+| Dotfiles repo | `/path/to/dotfiles` |
+| Obsidian vault | `/path/to/your/obsidian/vault` |
+| Bede preferences | `<vault>/Bede` |
+
+## Bede Repo
+
+Standalone repo for the Bede AI assistant. Contains the Claude CLI entrypoint, data-ingest server, data-mcp server, and CLAUDE.md.example template. Deployed as a prebuilt GHCR image referenced by `docker-compose.ai.yml`.
+
+## Dotfiles
+
+Scripts and launchd agents that collect data from the Mac and push it to Bede's data pipeline on the home server.
+
+Key scripts:
+- `scripts/daily-raw-collect.sh` — collects screen time, safari history, podcasts; POSTs to data-ingest
+- `scripts/claude-sessions.py` — summarises Claude Code sessions for the daily journal
+- `scripts/obsidian-git-backup.sh` — syncs Obsidian vault to git every 2 minutes
+- `scripts/bede-db.sh` — downloads Bede's SQLite DB from server for local inspection
+
+Launchd agents are in `launchd/` and symlinked to `~/Library/LaunchAgents/` via `install.sh`.
+
+## Obsidian Vault (PARA)
+
+Your PARA-organized Obsidian vault. Bede reads from and writes to this vault when deployed on the server (via git clone). Locally, it syncs via iCloud and the `obsidian-git-backup.sh` launchd job.
+
+## Bede Scheduling & Preferences
+
+Lives in the `Bede/` subdirectory of the vault. Contains:
+- `scheduled-tasks.md` — APScheduler job definitions that Bede runs on the server
+- `digest-sources.md` — sources for Bede's daily digest
+- Preference files (clothing, events, staples, vacuum, camping gear, etc.)
+
+When modifying Bede's scheduling or preferences, edit these vault files. They sync to the server via the vault git pipeline (Mac push every 2 min → server pull on Bede container start and vault task reload).


### PR DESCRIPTION
## Summary

- **`bede-deploy`** skill — automates the full Bede deployment pipeline: commit in bede repo → create PR → merge → wait for GHCR image build → SSH pull + restart on server
- **`bede-scout-config`** skill — add, remove, or update tracked items in Deal Scout preference files (clothing, groceries, camping gear, vacuum, events)

Both are dev-side skills used from the Mac to manage Bede — they don't run inside the Bede container.

## Test plan

- [ ] `/bede-deploy` walks through the full pipeline
- [ ] `/bede-scout-config` correctly identifies the right preference file and matches existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)