### PR TITLE
fix: pass HOMEPAGE_API_URL to bede container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -292,6 +292,12 @@ INGEST_WRITE_TOKEN=your-secure-ingest-write-token
 # Reads from SQLite (shared with data-ingest) and queries OwnTracks live.
 # -----------------------------------------------------------------------------
 
+# Service URLs for data-mcp external dependencies.
+# These are set in docker-compose.ai.yml using compose service names.
+# Override here only if running Bede outside this compose stack.
+# OWNTRACKS_URL=http://owntracks-recorder:8083
+# HOMEPAGE_API_URL=http://homepage-api:5000
+
 # OwnTracks user and device identifiers.
 # Find these by running: GET http://SERVER_IP:8083/api/0/list
 # then: GET http://SERVER_IP:8083/api/0/list?user=<user>

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -13,6 +13,7 @@ services:
       - INGEST_WRITE_TOKEN=${INGEST_WRITE_TOKEN}
       - DEFAULT_TIMEZONE=${TIMEZONE:-Australia/Sydney}
       - OWNTRACKS_URL=http://owntracks-recorder:8083
+      - HOMEPAGE_API_URL=http://homepage-api:5000
       - OWNTRACKS_USER=${OWNTRACKS_USER}
       - OWNTRACKS_DEVICE=${OWNTRACKS_DEVICE}
       - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID}


### PR DESCRIPTION
## Summary
- Add `HOMEPAGE_API_URL=http://homepage-api:5000` env var to `docker-compose.ai.yml`
- Document `OWNTRACKS_URL` and `HOMEPAGE_API_URL` overrides in `.env.example` for running Bede outside this compose stack

Depends on josephradford/bede#25 (must be merged and deployed together).

## Test plan
- [ ] `make validate` passes
- [ ] After bede GHCR image builds, `make bede-pull && make bede-restart`
- [ ] Verify weather and location tools still work via Bede

🤖 Generated with [Claude Code](https://claude.com/claude-code)