### PR TITLE
docs: Bede PRD and requirements document

### DIFF
--- a/docs/superpowers/specs/2026-04-28-bede-prd.md
+++ b/docs/superpowers/specs/2026-04-28-bede-prd.md
@@ -1,0 +1,684 @@
+# Bede Personal AI Assistant — Product Requirements Document
+
+**Version:** 1.0
+**Date:** 2026-04-28
+**Author:** Joe Radford + Claude
+**Status:** Draft — awaiting review
+
+---
+
+## 1. Vision
+
+Bede is a single-user personal AI assistant that runs on a home server, communicates via Telegram, and uses Claude as its reasoning engine. It observes Joe's daily life through data pipelines (health, screen time, location, calendar, email) and acts on scheduled tasks (morning briefings, evening reflections, deal scouting, email triage). It reads and writes to an Obsidian vault for persistent knowledge, journaling, and configuration.
+
+### What Bede is
+
+- A personal assistant with full context on Joe's day: health, activity, location, calendar, email, screen time, and goals.
+- A scheduled task runner that delivers briefings, reflections, and monitoring reports to Telegram at configured times.
+- A conversational interface for ad-hoc questions, drafting, and vault management.
+- An accountability partner that tracks goals, flags patterns, and provides honest feedback.
+
+### What Bede is not
+
+- A multi-user platform. Bede serves exactly one person.
+- A real-time agent that runs continuously. Bede is invoked per-message and per-task, with no persistent process beyond the scheduler.
+- A replacement for direct tool use. Bede augments, not replaces, direct use of calendar, email, and notes apps.
+
+### Design philosophy
+
+1. **Human-editable Markdown as configuration.** All persona, preferences, tasks, and memory files are plain Markdown in the Obsidian vault. No admin UI, no config database. If Bede breaks, Joe can fix it by editing a text file.
+2. **Claude CLI as the AI backbone.** Bede wraps `claude -p` (Claude Code headless mode), which provides tool use, session management, and MCP integration through the official, ToS-compliant CLI. No direct API calls.
+3. **Data flows in, intelligence flows out.** Data arrives via push (health, screen time, vault sync). Bede queries it via MCP tools. Output goes to Telegram and the vault. The data pipeline is passive; Bede is active only when invoked.
+4. **Net-simplicity over features.** Before adding anything, ask: does it solve a problem Joe actually has? Can it be added in a weekend? Does it reduce complexity elsewhere or just add a layer? Would Joe still want it after maintaining it for 2 years?
+
+---
+
+## 2. Users
+
+### Primary user
+
+Joe Radford — software engineer, Sydney, Australia. Sole operator and sole user.
+
+### User context
+
+- Edits Bede's configuration in Obsidian on Mac and iPhone (synced via iCloud + git).
+- Interacts with Bede via Telegram on phone and desktop.
+- Deploys Bede via SSH to the home server (`make bede-pull && make bede-restart`).
+- Monitors Bede via Prometheus/Grafana dashboards and Telegram error messages.
+- Has deep technical skills but limited time for maintenance — Bede must be low-friction to operate.
+
+### User needs
+
+| Need | Priority | Current state |
+|------|----------|---------------|
+| Morning context (calendar, weather, health) | P0 | Working (Morning Briefing task) |
+| Evening accountability (journal, goal tracking) | P0 | Working (Evening Reflection task) |
+| Ad-hoc conversation via Telegram | P0 | Working (chat handler) |
+| Email triage and action extraction | P1 | Working (Email Triage task) |
+| Deal and price monitoring | P1 | Working (Deal Scout task) |
+| Data pipeline health monitoring | P1 | Working (Evening Data Check task) |
+| Vault reading and writing | P0 | Working (Claude skills + git) |
+| Health pattern detection over time | P2 | Partial (single-day queries only, no trend analysis) |
+| Reliable, crash-free operation | P0 | Fragile (subprocess deadlocks, schema drift, silent failures) |
+| Easy to understand and modify | P0 | Degrading (growing complexity, no tests on core paths, no architecture docs) |
+
+---
+
+## 3. System Architecture
+
+### 3.1 High-level architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Home Server (Docker)                     │
+│                                                                 │
+│  ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌─────────────┐  │
+│  │ Telegram  │   │Scheduler │   │  Data    │   │  Data MCP   │  │
+│  │   Bot     │──▶│(APSched) │   │  Ingest  │   │  Server     │  │
+│  └────┬─────┘   └────┬─────┘   └────┬─────┘   └──────┬──────┘  │
+│       │              │              │                 │          │
+│       ▼              ▼              ▼                 │          │
+│  ┌─────────────────────────┐  ┌─────────┐    ┌──────┴──────┐   │
+│  │   Claude CLI (claude -p)│  │ SQLite  │◀───│  OwnTracks  │   │
+│  │   + MCP tool discovery  │  │   DB    │    │  Recorder   │   │
+│  └─────────┬───────────────┘  └─────────┘    └─────────────┘   │
+│            │                                                    │
+│  ┌─────────▼───────────────────────────────────────────────┐    │
+│  │              MCP Servers (HTTP, localhost)               │    │
+│  │  ┌──────────┐  ┌───────────────┐  ┌──────────────────┐  │    │
+│  │  │ data-mcp │  │ workspace-mcp │  │  playwright-mcp  │  │    │
+│  │  │ (8002)   │  │ (8003)        │  │  (8004)          │  │    │
+│  │  └──────────┘  └───────────────┘  └──────────────────┘  │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐                      │
+│  │ Traefik  │  │Fail2ban  │  │Prometheus│                      │
+│  │(reverse  │  │(intrusion│  │(metrics +│                      │
+│  │ proxy)   │  │ prevent) │  │ alerts)  │                      │
+│  └──────────┘  └──────────┘  └──────────┘                      │
+└─────────────────────────────────────────────────────────────────┘
+
+External inputs:
+  iPhone (HAE app) ──POST──▶ data-ingest (health data)
+  Mac (launchd jobs) ──POST──▶ data-ingest (screen time, Safari, podcasts, Claude sessions)
+  Mac (obsidian-git-backup) ──git push──▶ vault repo ──git pull──▶ /vault/
+  iPhone (OwnTracks) ──MQTT──▶ OwnTracks Recorder ──HTTP──▶ data-mcp
+  Google (OAuth) ──API──▶ workspace-mcp (Gmail, Calendar, Tasks)
+```
+
+### 3.2 Component inventory
+
+| Component | Location | Language | Purpose | Process |
+|-----------|----------|----------|---------|---------|
+| bot.py | bede repo | Python | Telegram bot + session management | supervisord |
+| scheduler.py | bede repo | Python | APScheduler cron task runner | imported by bot.py |
+| utils.py | bede repo | Python | Shared utilities (Markdown-to-Telegram-HTML converter) | imported by bot.py, scheduler.py |
+| collect_sessions.py | bede repo | Python | Nightly Bede session discovery, AI summarisation, and ingest | scheduled by APScheduler (2:00am) |
+| data-ingest | bede repo | Python | Starlette/Uvicorn async HTTP server receiving health/vault data | supervisord |
+| data-mcp | bede repo | Python | FastMCP server exposing personal data tools | supervisord |
+| workspace-mcp | pip package | Python | MCP server for Google Workspace | supervisord |
+| playwright-mcp | npm package | Node.js | MCP server for headless browser | supervisord |
+| entrypoint.sh | bede repo | Bash | Container init: SSH key setup, vault git clone/pull, supervisord launch | Docker entrypoint |
+| .claude/skills/ | bede repo | Markdown | Claude Code skills: `vault-write` (git commit+push), `journal-write` (5-step journal workflow with quality checks), `calendar-check` (multi-calendar lookup) | read by Claude CLI |
+| daily-raw-collect.sh | dotfiles repo | Bash | Mac data collection pipeline | launchd |
+| obsidian-git-backup.sh | dotfiles repo | Bash | Bidirectional vault git sync | launchd |
+| claude-sessions.py | dotfiles repo | Python | Claude Code session summarisation | called by daily-raw-collect |
+| biome-iphone-screentime.py | dotfiles repo | Python | iPhone screen time from Biome files | called by daily-raw-collect |
+
+### 3.3 Data stores
+
+| Store | Type | Writer | Reader | Location |
+|-------|------|--------|--------|----------|
+| bede.db | SQLite (WAL) | data-ingest | data-mcp | /data/sqlite/bede.db |
+| Obsidian vault | Git repo (Markdown) | Bede (journal, memory), Joe (preferences, tasks) | Bede (all tasks), Mac (iCloud sync) | /vault/ |
+| Claude project files | JSONL + metadata | Claude CLI | collect_sessions.py, Claude CLI (session resume) | ~/.claude/projects/ (bind-mounted to data/bede/claude-projects on host) |
+| workspace-mcp credentials | JSON files | workspace-mcp OAuth flow | workspace-mcp | /data/workspace-mcp/credentials/ |
+| Claude OAuth credentials | JSON | Claude CLI token refresh | Claude CLI | ~/.claude/.credentials.json (bind-mounted from host) |
+
+Note: Claude project files are persisted across container restarts via the bind mount. This means session resumption partially survives restarts (the JSONL files exist), though the in-memory session ID mapping in bot.py is lost. See Open Question #3.
+
+### 3.4 Network topology
+
+Bede's container connects to two Docker networks:
+- `homeserver` — shared with Traefik, Homepage API, and most services.
+- `location` — shared with OwnTracks Recorder and Mosquitto.
+
+Traefik exposes two Bede endpoints with different middleware:
+- `data.${DOMAIN}` → port 8001 (data-ingest) — uses `admin-secure@docker` (IP whitelist + security headers + rate limiting)
+- `mcp.${DOMAIN}` → port 8003 (workspace-mcp OAuth flow) — uses `admin-secure-no-ratelimit@docker` (IP whitelist + security headers, rate limiting disabled because the OAuth callback flow can trigger multiple rapid requests)
+
+The Telegram bot uses outbound-only long polling — no inbound web route.
+
+---
+
+## 4. Features
+
+### 4.1 Conversational chat (P0)
+
+**What it does:** Joe sends a Telegram message, Bede invokes `claude -p` with the message as the prompt, and returns the response. Multi-turn conversations are maintained by resuming the Claude session within a configurable timeout window.
+
+**Requirements:**
+- Messages invoke Claude CLI with session resumption for multi-turn context.
+- Session timeout is configurable via `SESSION_TIMEOUT_MINUTES` (code default: 10 minutes, but docker-compose.ai.yml overrides to 120 minutes in production). Interactive tasks have separate timeouts: `INTERACTIVE_IDLE_TIMEOUT_MINUTES` (default: 30) and `INTERACTIVE_MAX_AGE_HOURS` (default: 2).
+- Stale sessions (where Claude returns "no conversation found") are automatically retried with a fresh session.
+- OAuth auth failures are detected and surfaced to the user with re-auth instructions.
+- Responses are converted from Markdown to Telegram HTML format and chunked to respect the 4096-character Telegram message limit.
+- A typing indicator is shown while Claude is processing (every 4 seconds, with safety timeout).
+- Telegram commands for operational control:
+  - `/reset` — clears the current session and cancels all running tasks (kills subprocesses).
+  - `/start` — greeting.
+  - `/morning` — manually triggers Morning Briefing task.
+  - `/evening` — manually triggers Evening Reflection task.
+  - `/scout` — manually triggers Deal Scout task.
+  - `/datacheck` — manually triggers Evening Data Check task.
+  - `/triage` — manually triggers Email Triage task.
+
+**Current issues to resolve:**
+- Subprocess-based invocation is slow (CLI startup overhead per message) and fragile (process management, signal handling). The recent event loop deadlock (PR #25) is a symptom. Consider whether the Claude CLI's built-in session management is sufficient or whether a persistent connection model would be more reliable.
+- In-memory session state is lost on container restart. Session IDs should be persisted to SQLite or disk.
+- The Claude subprocess execution timeout (`CLAUDE_TIMEOUT = 120` seconds in bot.py) is hardcoded. This is distinct from the session timeout (`SESSION_TIMEOUT_MINUTES`) — the execution timeout is how long a single `claude -p` invocation can run before being killed, while the session timeout controls how long a multi-turn conversation stays active. Make the execution timeout configurable via env var.
+- Environment variable filtering is inconsistent: scheduled tasks strip `TELEGRAM_BOT_TOKEN` and `ALLOWED_USER_ID` from the Claude subprocess environment (via `scheduler.py:_get_task_env()`), but chat message invocations in `bot.py:_run_claude()` inherit the full environment. This means Claude has access to the bot token during ad-hoc chats but not during scheduled tasks.
+
+### 4.2 Scheduled tasks (P0)
+
+**What it does:** APScheduler runs cron-triggered tasks defined in the Obsidian vault's `scheduled-tasks.md`. Each task invokes Claude with a specific prompt, optional multi-step execution, and delivers results to Telegram.
+
+**Requirements:**
+- Tasks are defined in a YAML code block (` ```yaml ... ``` `) within a Markdown file in the vault. Note: this is a fenced code block, not YAML frontmatter (which uses `---` delimiters). The distinction matters for Obsidian rendering.
+- The task file is hot-reloaded every 5 minutes — changes take effect without restart.
+- Each task specifies: name, cron schedule, prompt, model, timeout, and optional flags (interactive, parallel, steps, preamble, silent).
+- Multi-step tasks can run steps sequentially or in parallel via `asyncio.gather`.
+- Silent steps execute but don't deliver output to Telegram (used for memory updates).
+- Interactive tasks hand the session to the chat handler after completion, allowing Joe to reply with corrections.
+- Corrections from interactive tasks are appended to `reflection-memory.md` in the vault.
+- A task cannot run concurrently with itself (duplicate prevention).
+- Tasks run in their own process group for clean timeout/cancellation via SIGTERM → SIGKILL escalation.
+- Per-task model and timeout overrides.
+
+**Current tasks:**
+
+| Task | Schedule | Model | Type |
+|------|----------|-------|------|
+| Morning Briefing | Weekdays 8:00am | Sonnet | Sequential |
+| Evening Data Check | Daily 8:00pm | Haiku | Non-interactive |
+| Email Triage | Weekdays 8:30pm | Sonnet | Interactive |
+| Evening Reflection | Daily 9:00pm | Sonnet | Interactive |
+| Deal Scout | Sundays 2:00pm | Sonnet | Parallel (5+1 steps) |
+
+**Current issues to resolve:**
+- Process management complexity (SIGTERM/SIGKILL, process groups, `start_new_session=True`) is a recurring source of bugs. The recent deadlock fix moved `proc.wait()` to a thread, but the underlying architecture remains fragile.
+- No retry logic for transient failures. A failed task is simply lost.
+- No task execution history or audit trail. When a task fails, there is no record of what happened or when.
+- Vault git pull (`_pull_vault()`) catches all exceptions and passes silently. A failed git pull means Claude operates on stale data.
+
+### 4.3 Data ingest pipeline (P0)
+
+**What it does:** Async HTTP server (Starlette on Uvicorn) receives structured data from external sources (iPhone health app, Mac nightly collection scripts) and stores it in SQLite for querying by data-mcp.
+
+**Requirements:**
+- `POST /ingest/health` — receives Apple Health data from the Health Auto Export iPhone app. Parses metrics (steps, energy, exercise, stand hours, heart rate, HRV, mindfulness), sleep analysis, workouts, state of mind, and medications. Bearer token authentication.
+- `POST /ingest/vault` — receives CSV-in-JSON payloads from the Mac's `daily-raw-collect.sh`. Parses screen time (Mac + iPhone), Safari history, YouTube history, podcasts, Claude sessions, and Bede sessions. Full daily replacement for screen time and Safari data. Bearer token authentication.
+- `GET /health` — health check endpoint, no auth.
+- SQLite database with WAL mode for concurrent reads.
+- Schema version tracking with migration support.
+
+**Current issues to resolve:**
+- Schema is duplicated between `data-ingest/db.py` and `data-mcp/sources/db.py`. The data-mcp copy is already out of sync (missing `bede_sessions` table). Extract a shared schema module.
+- No input validation beyond basic type checking. Malformed payloads can cause silent data corruption.
+- No data retention policy. The database grows indefinitely.
+
+### 4.4 Personal data MCP server (P0)
+
+**What it does:** FastMCP server exposing personal data as MCP tools that Claude can call during inference.
+
+**Requirements:**
+
+Vault-based tools (SQLite queries):
+- `get_screen_time(date, device, top_n, timezone)` — app and web domain usage.
+- `get_safari_history(date, device, domain_filter, top_n, timezone)` — Safari page visits.
+- `get_youtube_history(date, timezone)` — YouTube visits (with Safari fallback).
+- `get_podcasts(date, timezone)` — podcast episodes.
+- `get_claude_sessions(date, timezone)` — Claude Code session summaries.
+- `get_bede_sessions(date, timezone)` — Bede session summaries.
+
+Health tools (SQLite queries):
+- `get_sleep(date, timezone)` — bedtime, wake time, duration, stages.
+- `get_activity(date, timezone)` — steps, calories, exercise, stand hours.
+- `get_workouts(date, timezone)` — workout type, duration, energy, heart rate.
+- `get_heart_rate(date, timezone)` — resting HR and HRV.
+- `get_wellbeing(date, timezone)` — mindfulness minutes, state of mind entries.
+- `get_medications(date, timezone)` — medication logs.
+
+Live API tools:
+- `get_location_summary(date, timezone)` — GPS clustering with reverse geocoding via Nominatim. Queries OwnTracks Recorder.
+- `get_location_raw(from_date, to_date, timezone)` — raw GPS points from OwnTracks.
+- `get_weather()` — current BOM observations + 7-day forecast. Delegates entirely to the homepage-api service (`docker-compose.dashboard.yml`); if homepage-api is down, weather queries fail.
+
+All tools accept natural date strings (`'today'`, `'yesterday'`, `'last_night'`, `'YYYY-MM-DD'`). All handle timezone conversion internally (default: `Australia/Sydney` via `DEFAULT_TIMEZONE` env var).
+
+**Known discrepancy:** The `CLAUDE.md.example` template (line 78) documents a `get_vault_changes(date)` tool ("Obsidian vault git commits") that does not exist in the data-mcp codebase. This phantom tool reference will cause Claude to attempt calls that fail. Either implement the tool or remove it from the template.
+
+**Current issues to resolve:**
+- In-memory geocoding cache is lost on container restart. Consider persisting to SQLite.
+- No trend analysis tools (e.g., "sleep quality over the past week", "exercise trend this month"). Single-day queries only.
+- No error handling for OwnTracks or Homepage API being unreachable — queries fail with unhandled exceptions.
+- Timezone configuration is split: bot/scheduler use `TIMEZONE` (default: UTC), data-mcp uses `DEFAULT_TIMEZONE` (default: Australia/Sydney). In production, docker-compose.ai.yml bridges these via `DEFAULT_TIMEZONE=${TIMEZONE:-Australia/Sydney}`, but if `TIMEZONE` is unset in `.env`, bot/scheduler default to UTC while data-mcp defaults to Sydney, producing timezone-mismatched query results.
+
+### 4.5 Google Workspace integration (P1)
+
+**What it does:** Third-party MCP server (`workspace-mcp`) provides Gmail, Google Calendar, and Google Tasks access via OAuth.
+
+**Requirements:**
+- Gmail: search, read, send, reply.
+- Google Calendar: list calendars, get events (must check ALL calendars, not just primary).
+- Google Tasks: list, create.
+- OAuth 2.0 flow via Traefik-proxied browser callback.
+- Single-user mode.
+
+**Current issues to resolve:**
+- OAuth credential storage is on disk with no backup mechanism. If the volume is lost, re-auth is required.
+- The `workspace-mcp` package is a third-party dependency with loose version pinning (`>= 1.17`). Breaking changes could affect the integration silently.
+
+### 4.6 Browser automation (P2)
+
+**What it does:** Playwright MCP provides headless Chromium for web scraping tasks (primarily Deal Scout).
+
+**Requirements:**
+- Headless Chromium with `--no-sandbox` (required for non-root container).
+- Accessible to Claude via MCP tool discovery.
+
+**Current issues to resolve:**
+- `@playwright/mcp@latest` is unpinned. Pin to a specific version.
+
+### 4.7 Mac data collection pipeline (P0)
+
+**What it does:** LaunchD-scheduled scripts on Joe's Mac collect daily data and POST it to the server.
+
+**Requirements:**
+- Screen time collection from `knowledgeC.db` (Mac) and Biome SEGB files (iPhone via iCloud).
+- Safari history from `History.db` (Mac + iPhone visits via iCloud sync).
+- YouTube visits extracted from Safari history.
+- Podcast listening from Apple Podcasts `MTLibrary.sqlite`.
+- Claude Code session summaries via AI summarisation.
+- Collection runs 8 times daily: every 30 minutes from 5:00pm-8:00pm (7 runs), then once at 11:00pm. Schedule defined in launchd plist `StartCalendarInterval`.
+- Midday-boundary date logic: before noon = yesterday's data, noon onward = today's. This handles the evening-to-past-midnight collection window.
+- Skip launchd catch-up runs between 3am-4:59pm (`CURRENT_HOUR >= 3 && CURRENT_HOUR < 17`) to prevent unwanted daytime runs when macOS coalesces missed `StartCalendarInterval` events on wake from sleep. Manual daytime runs are allowed (only blocked when `LAUNCH_JOB_LABEL` env var is set by launchd).
+- POST payload as JSON with Bearer token authentication.
+
+**Current issues to resolve:**
+- Biome SEGB parsing is fragile — manual protobuf decoding without a schema. Apple format changes will break it silently.
+- Claude session summarisation is expensive (one `claude -p` call per session with 90-second timeout).
+- No error alerting. Failed POSTs log to `/tmp/` files but there is no push notification.
+- Hardcoded paths throughout (acceptable for personal dotfiles, but should be documented).
+- README is outdated — doesn't mention several scripts.
+
+### 4.8 Vault sync (P0)
+
+**What it does:** Bidirectional git sync between the Mac's Obsidian vault (iCloud) and the server's vault clone.
+
+**Requirements:**
+- Runs every 2 minutes via launchd.
+- Uses split git layout (`GIT_DIR` separate from `GIT_WORK_TREE`) to keep `.git` out of iCloud.
+- Commit local changes first, then pull --rebase, then push.
+- On rebase conflict: abort rebase and fall back to merge (single attempt, not retry).
+- Retry up to 3 times with 10-second sleep for transient SSH failures.
+
+**Current issues to resolve:**
+- Merge conflicts can still occur and require manual resolution. This is rare but disruptive when it happens.
+- The Bede container's vault pull (`_pull_vault()`) swallows all git errors silently. Should at minimum log the failure.
+
+---
+
+## 5. Cross-Cutting Concerns
+
+### 5.1 Security
+
+**Threat model:** Bede runs on a home server behind WireGuard VPN and RFC1918 IP whitelisting. The primary threats are:
+
+1. **Data exfiltration via prompt injection.** Claude processes external content (emails, web pages, vault files). A crafted prompt in any of these could attempt to exfiltrate personal data via tool calls.
+2. **Credential exposure.** Claude runs with `--dangerously-skip-permissions`, giving it unrestricted access to all MCP tools and filesystem operations.
+3. **Stale OAuth tokens.** Claude OAuth tokens expire and require manual re-auth on the Mac, creating operational risk.
+4. **Data pipeline authentication.** The ingest endpoints use Bearer tokens over HTTPS, behind IP whitelist middleware.
+
+**Requirements:**
+- All external-facing endpoints (data-ingest, workspace-mcp OAuth) must be behind the `admin-secure` Traefik middleware chain (IP whitelist + security headers + rate limiting).
+- The Telegram bot token must never be visible to Claude subprocesses. Currently only enforced for scheduled tasks (via `scheduler.py:_get_task_env()`); chat message invocations in `bot.py:_run_claude()` do not filter the environment. This asymmetry should be resolved.
+- Bearer tokens for data-ingest must be strong (>= 32 characters) and rotatable.
+- No secrets in git. All credentials in `.env` (gitignored) or bind-mounted files.
+- Claude's `--dangerously-skip-permissions` is accepted as a necessary trade-off for MCP tool use. Mitigate by restricting the vault write scope in CLAUDE.md rules.
+
+**Future considerations (from Hermes/OpenClaw research):**
+- Wrap external content (emails, web pages) with untrusted-content markers to reduce prompt injection risk.
+- Scan memory writes for injection patterns (exfiltration attempts, invisible Unicode).
+- Consider per-task tool restrictions (e.g., Deal Scout should not have email access).
+
+### 5.2 Reliability
+
+**Current state:** Bede has experienced multiple production incidents in its 23-day history, including event loop deadlocks, state desync, and silent data pipeline failures.
+
+**Requirements:**
+- Graceful degradation: individual component failures must not cascade. A data-ingest crash should not stop the Telegram bot.
+- Timeout handling: all Claude CLI invocations must have configurable timeouts with clean process termination and event loop safety (no blocking `proc.wait()`). Note: the current behavior differs between components — the scheduler does SIGTERM → 10s wait → SIGKILL (process group), while bot.py goes straight to SIGKILL on timeout. These should be unified.
+- Session recovery: stale Claude sessions must be automatically retried with fresh sessions.
+- Error surfacing: failures in scheduled tasks and data pipelines must be reported to Telegram, not swallowed silently.
+- Vault git operations must log failures and surface them (currently they pass silently).
+
+**Future considerations:**
+- Task execution audit trail (task name, start time, duration, success/failure, token usage) persisted to SQLite.
+- Container health checks beyond process liveness (e.g., check that the scheduler has tasks loaded, that SQLite is writable).
+- Consider splitting the single container into separate services for independent scaling and restart.
+
+### 5.3 Observability
+
+**Current state:** No application-level metrics or alerting. Container-level monitoring exists via cAdvisor/Prometheus.
+
+**Requirements:**
+- Prometheus metrics endpoint exposing: task execution count/duration/status, message count/latency, data ingest payload count/errors, MCP tool call count/errors.
+- Grafana dashboard for Bede operational health.
+- Alertmanager rules for: task failures, data pipeline gaps (no health data for > 24 hours), Claude auth failures, sustained high error rates.
+
+### 5.4 Testing
+
+**Current state:** ~133 tests covering data-ingest parsers, data-mcp queries, and interactive session management. No tests on bot.py core (message handling, output parsing, Markdown-to-HTML), scheduler task execution, or end-to-end paths. No CI test step — the GitHub Actions workflow only builds and pushes the Docker image.
+
+**Requirements:**
+- Unit tests for all core bot functions: message parsing, output parsing, session management, Markdown-to-HTML conversion.
+- Unit tests for scheduler: task parsing, step execution, parallel execution, timeout handling, duplicate prevention.
+- Integration tests for data pipelines: ingest → SQLite → MCP tool query round-trip.
+- CI pipeline (GitHub Actions) must run tests before building the Docker image. Fail the build on test failure.
+- Target: >= 70% line coverage on new code, increasing over time.
+
+### 5.5 Extensibility
+
+**Design principles for future growth:**
+
+1. **New MCP tools** are the primary extension mechanism. Adding a new data source means: (a) add an ingest endpoint or data source, (b) add an MCP tool that queries it, (c) reference the tool in task prompts. No bot.py changes needed.
+
+2. **New scheduled tasks** require only a new entry in `scheduled-tasks.md`. The YAML schema supports single-step, multi-step sequential, multi-step parallel, and interactive variants.
+
+3. **New messaging platforms** (if ever needed) would require a platform adapter pattern (like Hermes/OpenClaw's gateway), but this is explicitly not planned. Telegram is the sole interface.
+
+4. **Claude Code Skills** (`.claude/skills/`) provide reusable procedures that Claude can invoke during any task. New skills are added as Markdown files — no code changes.
+
+### 5.6 Performance
+
+**Requirements:**
+- Chat response time: < 30 seconds from message to first response (dominated by Claude CLI startup + inference time).
+- Scheduled task completion: within configured timeout (default 300s, up to 2400s for Deal Scout).
+- Data ingest latency: < 2 seconds per POST request.
+- MCP tool response time: < 5 seconds for SQLite queries, < 15 seconds for location (geocoding), < 10 seconds for weather (external API).
+
+---
+
+## 6. Known Architectural Debt
+
+These are known problems inherited from Bede's rapid 23-day development. The PRD acknowledges them as tech debt to be addressed incrementally, not as blockers.
+
+| # | Issue | Impact | Severity |
+|---|-------|--------|----------|
+| 1 | **Subprocess-based Claude invocation** — every message/task spawns a new `claude -p` process. Slow startup, fragile process management, source of deadlock bugs. | Latency, reliability | High |
+| 2 | **Schema duplication** — SQLite schema copy-pasted between data-ingest and data-mcp. Already out of sync. | Data integrity | High |
+| 3 | **Single-container supervisord** — all 5 services in one container. No independent restart or scaling. | Reliability | Medium |
+| 4 | **In-memory state** — session IDs, geocoding cache lost on restart. | UX, performance | Medium |
+| 5 | **No CI tests** — Docker image builds without running tests. | Quality | High |
+| 6 | **Silent git failures** — vault pull errors are caught and ignored. | Data freshness | Medium |
+| 7 | **Unpinned dependencies** — `@playwright/mcp@latest`, `workspace-mcp >= 1.17`, Claude CLI from `curl \| bash`. | Reproducibility | Medium |
+| 8 | **No task audit trail** — task execution results are not persisted anywhere. | Observability | Medium |
+| 9 | **No data retention policy** — SQLite database grows without bound. | Disk usage | Low |
+| 10 | **Hardcoded Claude execution timeout** — `CLAUDE_TIMEOUT = 120` seconds in bot.py is not configurable via env var. (Distinct from `SESSION_TIMEOUT_MINUTES`, which controls multi-turn session lifetime.) | Flexibility | Low |
+| 11 | **Timezone env var inconsistency** — bot/scheduler use `TIMEZONE` (default: UTC), data-mcp uses `DEFAULT_TIMEZONE` (default: Australia/Sydney). Bridged in docker-compose but fragile. | Correctness | Medium |
+| 12 | **Phantom tool in CLAUDE.md.example** — `get_vault_changes(date)` is documented but not implemented. Causes Claude to attempt non-existent tool calls. | UX | Medium |
+| 13 | **Legacy scripts/briefing.sh** — referenced in Dockerfile `chmod` but likely dead code from pre-scheduler era. Should be removed or documented. | Clarity | Low |
+
+---
+
+## 7. Patterns Borrowed from Hermes and OpenClaw
+
+After research into both projects, the following patterns pass the "steal-if-it-fits" filter from the vault note:
+
+### Adopted
+
+| Pattern | Source | Why | How it applies |
+|---------|--------|-----|----------------|
+| **Frozen memory snapshots for prompt caching** | Hermes | Prevents cache-breaking mid-session. Load memory at session start, write to disk immediately, never mutate the system prompt mid-session. | Apply to Bede's session management: load vault files once per task/message, don't re-read mid-conversation. |
+| **Shared schema module** | Both | Both projects use single-source-of-truth for data schemas. | Extract SQLite schema from data-ingest/data-mcp duplication into a shared module. |
+| **Untrusted content wrapping** | OpenClaw | External content (emails, web scrapes) should be explicitly marked to reduce prompt injection risk. | Add content markers in prompts when processing external data. |
+| **Task execution audit trail** | Both | Both projects persist task results for debugging and analysis. | Add a `task_executions` table to SQLite. |
+| **CI test gate** | Both | Both run tests before building. | Add pytest step to GitHub Actions workflow. |
+
+### Deferred (watch list)
+
+| Pattern | Source | Why deferred |
+|---------|--------|-------------|
+| **Auto-created skills** | Hermes | Needs manual validation first. Follow the experiment outlined in the vault note: `/skill` command, inbox directory, weekly review, measure promote-rate before automating. |
+| **Heartbeat batching** | OpenClaw | Current separate cron tasks are fine at 5 tasks. Revisit if task count grows significantly. |
+| **Semantic memory search** | Both | Overkill for current vault size. Revisit if Bede's memory grows beyond what can fit in a system prompt. |
+| **Multi-platform gateway** | Both | Telegram is sufficient. No need for Discord/Slack/etc. |
+| **Dreaming/consolidation** | OpenClaw | Interesting but speculative. The `reflection-memory.md` manual correction pattern is working. |
+| **Progressive skill disclosure** | Both | Currently only 3 Claude Code skills. Lazy-loading overhead not justified. |
+
+### Rejected
+
+| Pattern | Source | Why rejected |
+|---------|--------|-------------|
+| **Self-updating user model** | Both | Violates trust boundary. Joe is source of truth for `user.md`. See vault note's analysis of dialectic approach. |
+| **In-process tool registry** | Hermes | MCP is the right abstraction for Bede — out-of-process, language-agnostic, session-resumable. |
+| **Smart approval mode** | Hermes | Bede runs with `--dangerously-skip-permissions` by design. Adding approval would defeat the purpose. |
+| **Device pairing** | OpenClaw | Single-user, single-device. Telegram `ALLOWED_USER_ID` is sufficient. |
+
+---
+
+## 8. Configuration Reference
+
+### 8.1 Environment variables
+
+All configuration is via `.env` on the server. See `.env.example` for the complete list.
+
+**Core:**
+- `TELEGRAM_BOT_TOKEN` — Telegram bot API token (required)
+- `ALLOWED_USER_ID` — numeric Telegram user ID for authentication (required)
+- `CLAUDE_MODEL` — default Claude model (default: `claude-haiku-4-5-20251001`, overridable per task)
+- `CLAUDE_WORKDIR` — working directory for Claude CLI (default: `/app`)
+- `SESSION_TIMEOUT_MINUTES` — chat session timeout in minutes (code default: 10, docker-compose override: 120)
+- `INTERACTIVE_IDLE_TIMEOUT_MINUTES` — interactive task idle timeout (default: 30)
+- `INTERACTIVE_MAX_AGE_HOURS` — interactive task max lifetime (default: 2)
+- `TIMEZONE` — local timezone for bot/scheduler (default: `UTC`). Also used to derive `DEFAULT_TIMEZONE` in docker-compose.
+- `ANTHROPIC_API_KEY` — explicitly set to empty in docker-compose.ai.yml to force OAuth (never set this to a real key)
+
+**Vault:**
+- `VAULT_REPO` — git URL for Obsidian vault
+- `VAULT_SSH_KEY_PATH` — SSH key for vault access
+- `BEDE_TASKS_PATH` — path to scheduled tasks file relative to vault root (default: `Bede/scheduled-tasks.md`)
+
+**Data pipeline:**
+- `SQLITE_DB_PATH` — SQLite database path (default: `/data/bede.db`, docker-compose sets `/data/sqlite/bede.db`)
+- `INGEST_WRITE_TOKEN` — Bearer token for data-ingest endpoints (required)
+- `INGEST_URL` — internal URL for vault data ingest (default: `http://localhost:8001/ingest/vault`)
+- `DEFAULT_TIMEZONE` — timezone for data-mcp tools (default: `Australia/Sydney`, set via `${TIMEZONE:-Australia/Sydney}` in docker-compose)
+- `OWNTRACKS_URL` — OwnTracks Recorder URL (default: `http://owntracks-recorder:8083`)
+- `OWNTRACKS_USER` / `OWNTRACKS_DEVICE` — OwnTracks identifiers
+- `HOMEPAGE_API_URL` — Homepage API URL for weather data (default: `http://homepage-api:5000`)
+- `NOMINATIM_URL` — reverse geocoding service URL (default: `https://nominatim.openstreetmap.org/reverse`)
+- `BOM_LOCATION` — BOM weather location
+
+**Google Workspace:**
+- `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` — OAuth credentials (required)
+- `GOOGLE_OAUTH_REDIRECT_URI` — OAuth callback URL (derived from `DOMAIN` in docker-compose)
+- `GOOGLE_MCP_CREDENTIALS_DIR` — workspace-mcp credential storage path
+- `MCP_SINGLE_USER_MODE` — workspace-mcp single user mode (default: `true`)
+- `USER_GOOGLE_EMAIL` — Google account email
+
+### 8.2 Vault configuration files
+
+All in `/vault/Bede/`:
+
+| File | Purpose | Editor |
+|------|---------|--------|
+| `scheduled-tasks.md` | Task definitions (YAML in Markdown) | Joe |
+| `soul.md` | Personality, tone, values, boundaries | Joe |
+| `user.md` | User profile and context | Joe |
+| `journal-template.md` | Journal entry template | Joe |
+| `digest-sources.md` | Morning briefing news sources | Joe |
+| `reflection-memory.md` | Corrections to reflection behaviour | Bede (appends), Joe (reviews) |
+| `price-checker-memory.md` | Deal Scout operational memory | Bede (reads/writes) |
+| `scout-rules.md` | Shared methodology for all Deal Scout categories | Joe |
+| `clothing-preferences.md` | Clothing brands, sizes, retailers, thresholds | Joe |
+| `event-preferences.md` | Event artists, venues, ticketing sources | Joe |
+| `staples.md` | Grocery/household items and retailers | Joe |
+| `vacuum-preferences.md` | Vacuum product research and requirements | Joe |
+| `camping-gear.md` | Camping gear product URLs and target prices | Joe |
+
+**Templates** (in bede repo root, not committed to vault):
+- `CLAUDE.md.example` — template for the system prompt/persona file.
+- `user.md.example` — template for the vault user profile (`/vault/Bede/user.md`).
+- `scheduled-tasks.example.md` — template for the vault task definitions.
+
+### 8.3 System prompt
+
+The system prompt (`/app/CLAUDE.md`) is bind-mounted into the container, personal (not committed to git), and follows the template in `CLAUDE.md.example`. It defines:
+
+- Identity and tone
+- References to soul.md and user.md in the vault
+- Capability list (what Bede can and cannot do)
+- Rules for behaviour
+- Personal data tool reference (all MCP tool names with parameters)
+- Google account configuration
+- Calendar access instructions
+
+---
+
+## 9. Deployment
+
+### 9.1 Container deployment
+
+Bede runs as a single Docker container (`ghcr.io/josephradford/bede:latest`) managed by `docker-compose.ai.yml` in the home-server-stack repo. The image is built by GitHub Actions on every merge to `main` in the bede repo.
+
+**Container startup sequence** (via `scripts/entrypoint.sh`):
+1. Configure SSH key for vault access (if `VAULT_SSH_KEY_PATH` is set).
+2. Clone or pull the Obsidian vault from `VAULT_REPO` to `/vault/`.
+3. Launch supervisord (PID 1), which starts all 5 services.
+
+**Deploy workflow:**
+1. Make changes in the bede repo, create a PR, merge to `main`.
+2. Wait for GitHub Actions to build and push the new GHCR image.
+3. On the server: `make bede-pull && make bede-restart`.
+
+### 9.2 Mac-side deployment
+
+The dotfiles repo manages Mac-side data collection via `install.sh`, which symlinks scripts and launchd plists into place.
+
+**Deploy workflow:**
+1. Make changes in the dotfiles repo.
+2. Run `./install.sh` to update symlinks.
+3. `launchctl unload && launchctl load` for changed plists.
+
+### 9.3 Vault configuration deployment
+
+Vault changes sync automatically via the bidirectional git pipeline (every 2 minutes Mac → server, `scheduled-tasks.md` reloaded every 5 minutes by the scheduler).
+
+---
+
+## 10. Success Criteria
+
+### Short-term (resolve current pain)
+
+- [ ] Implement task execution audit trail in SQLite, then measure 30 days of zero deadlocks/event loop freezes.
+- [ ] CI pipeline runs tests and fails on test failure before building Docker image.
+- [ ] Schema duplication eliminated — single source of truth.
+- [ ] All silent failures surface via Telegram error messages or Prometheus alerts.
+- [ ] Phantom `get_vault_changes` tool either implemented or removed from CLAUDE.md.example.
+- [ ] Environment filtering applied consistently to both chat and scheduled task Claude invocations.
+
+### Medium-term (robustness)
+
+- [ ] >= 40% test coverage on bot.py and scheduler.py core paths (intermediate milestone toward 70%).
+- [ ] Grafana dashboard showing Bede operational health.
+- [ ] Alertmanager rules for data pipeline gaps and task failures.
+- [ ] Container health checks beyond process liveness.
+- [ ] All dependencies version-pinned.
+
+### Long-term (quality of life)
+
+- [ ] Health trend analysis tools (weekly/monthly summaries, pattern detection).
+- [ ] Experiment with auto-created skills (manual trigger first, measure promote-rate).
+- [ ] Data retention policy with configurable TTLs.
+- [ ] Consider container decomposition if single-container becomes a reliability bottleneck.
+
+---
+
+## 11. Open Questions
+
+These are decisions that need Joe's input before implementation planning:
+
+1. **Container architecture:** Keep single container with supervisord, or split into separate containers (bot, data-ingest, data-mcp, workspace-mcp, playwright-mcp)? Splitting improves isolation but adds deployment complexity.
+
+2. **Claude CLI vs SDK:** Bede currently wraps `claude -p` as a subprocess. The Claude Agent SDK exists as an alternative that would give in-process control, streaming, and eliminate subprocess management. Trade-off: SDK uses API tokens (per-token cost) vs CLI uses subscription (flat cost). At current usage levels (~50-100k tokens/day), what's the cost comparison? Note: `ANTHROPIC_API_KEY` is explicitly set to empty in docker-compose.ai.yml as an intentional safeguard against accidental API usage — any SDK migration would need to deliberately reverse this.
+
+3. **Session persistence:** Should session IDs be persisted to SQLite so multi-turn conversations survive container restarts? Or is the current "fresh session on restart" acceptable?
+
+4. **Data retention:** How long should personal data be kept? Indefinitely? 1 year? Should there be different retention policies for different data types?
+
+5. **Trend analysis scope:** What time windows matter most? Weekly summaries? Monthly? Quarterly? What patterns should Bede look for?
+
+6. **Skills experiment:** Ready to try the `/skill` command experiment outlined in the vault note? Or defer?
+
+7. **Vault pull failure behavior:** When `_pull_vault()` fails before a task, what should happen? Options: (a) log and continue with stale data (current), (b) log and notify via Telegram so Joe knows the task ran on stale data, (c) fail the task entirely. Different tasks may warrant different behavior.
+
+8. **Chat environment filtering:** Should chat message invocations also strip `TELEGRAM_BOT_TOKEN` from the Claude subprocess environment, matching the scheduler's behavior? The current asymmetry is a low-severity security gap.
+
+9. **Schema migration strategy:** `data-ingest/db.py` has `SCHEMA_VERSION = 3` but no migration logic — no code reads the current version and applies ALTER TABLE statements. If the schema changes, the database must be recreated. Should we add proper migration support, or is manual recreation acceptable for a single-user system?
+
+10. **Entrypoint script vs. init container:** The current `entrypoint.sh` does SSH key setup, vault git clone/pull, and supervisord launch. If the container splits into separate services (Q1), this initialization logic would need to be refactored. Worth considering now?
+
+---
+
+## Appendix A: Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Claude CLI** | The `claude` command-line tool, invoked via `claude -p` for headless (non-interactive) mode |
+| **MCP** | Model Context Protocol — Anthropic's standard for connecting LLMs to external tools and data sources |
+| **FastMCP** | Python framework for building MCP servers |
+| **APScheduler** | Advanced Python Scheduler — library for cron-like job scheduling |
+| **HAE** | Health Auto Export — iPhone app that exports Apple Health data via HTTP |
+| **OwnTracks** | Open-source location tracking (iPhone app + server recorder) |
+| **GHCR** | GitHub Container Registry — where Bede's Docker image is published |
+| **Supervisord** | Process manager that runs multiple services inside a single container |
+| **Biome** | Apple's telemetry data format, stored as SEGB (Structured Event Graph Binary) files |
+| **workspace-mcp** | Third-party MCP server for Google Workspace (Gmail, Calendar, Tasks) |
+
+## Appendix B: Data Pipeline Timing
+
+```
+MAC-SIDE (launchd)                    SERVER-SIDE (APScheduler in Bede container)
+
+5:00pm  ──┐
+5:30pm  ──┤
+6:00pm  ──┤  daily-raw-collect.sh
+6:30pm  ──┤  POSTs screen time, Safari,
+7:00pm  ──┤  podcasts, YouTube, Claude
+7:30pm  ──┤  sessions to data-ingest
+8:00pm  ──┘
+                                      8:00pm  ── Evening Data Check
+                                      8:30pm  ── Email Triage (weekdays)
+                                      9:00pm  ── Evening Reflection
+
+11:00pm ── Final collection run
+
+                                      2:00am  ── Bede session collection
+                                                  (collect_sessions.py, server-side)
+
+                                      8:00am  ── Morning Briefing (weekdays)
+                                      2:00pm  ── Deal Scout (Sundays)
+```
+
+Vault sync (Mac ↔ Server) runs continuously every 2 minutes via `obsidian-git-backup.sh`.
+
+## Appendix C: Repository Map
+
+| Repository | Purpose | Deploy target |
+|------------|---------|---------------|
+| `josephradford/bede` | Bede source code (bot, data-ingest, data-mcp, skills) | GHCR Docker image → home server |
+| `josephradford/home-server-stack` | Infrastructure stack (Docker Compose, Traefik, monitoring) | Home server via SSH + git pull |
+| `josephradford/dotfiles` | Mac data collection scripts and launchd agents | Mac via install.sh |
+| Obsidian vault (private) | Configuration, preferences, tasks, journal, memory | iCloud + git (bidirectional) |

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -79,7 +79,7 @@ If the user does not respond to the interactive prompt, Bede retries up to three
 
 **I want my personal knowledge base to grow naturally and be easy to search.**
 
-Bede must integrate with the user's personal knowledge base (currently an Obsidian vault organised using the PARA method). It must be able to read from and write to the knowledge base. Writing includes: journal entries, meeting notes, captured ideas, task outcomes, and any other structured or unstructured content the user asks it to record.
+Bede must integrate with the user's personal knowledge base. It must be able to read from and write to the knowledge base. Writing includes: journal entries, meeting notes, captured ideas, task outcomes, and any other structured or unstructured content the user asks it to record.
 
 "Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should suggest where to file things and how to organise them, but the user makes the final decision. Bede does not file autonomously.
 
@@ -91,21 +91,7 @@ The knowledge base must be stored as files the user owns and controls (Markdown 
 
 **Measurable indicator:** The user can capture a thought in under 10 seconds (voice or text). Bede can answer a question using vault content when relevant notes exist.
 
-### R6. Deal and price monitoring
-
-**I want deals and prices monitored on things I care about.**
-
-Bede must track prices and availability for products and events the user specifies. Categories include clothing, household staples, outdoor gear, event tickets, and whatever the user adds in future. The user defines what to watch, what retailers to check, and what constitutes a deal worth reporting.
-
-Monitoring must run on a configurable schedule. Reports should only surface when something actionable has changed — a price drop, a restock, a new event announced. No-change reports are noise.
-
-Bede must be able to browse the web to check prices and availability, since many retailers don't offer APIs.
-
-**Success looks like:** The user gets timely alerts about deals they care about without manually checking websites.
-
-**Measurable indicator:** Price alerts are delivered within 24 hours of a price change on a monitored item.
-
-### R7. Conversational assistant
+### R6. Conversational assistant
 
 **I want a conversational assistant I can ask anything, with full context on my life.**
 
@@ -119,7 +105,7 @@ This must not be limited to any specific domain. If the user asks about cooking,
 
 **Measurable indicator:** Bede incorporates personal context (calendar, health, goals, or vault) in responses where relevant, without the user having to ask for it.
 
-### R8. Voice interaction
+### R7. Voice interaction
 
 **I want to talk to Bede by voice, and have Bede talk back — especially on the go.**
 
@@ -131,7 +117,7 @@ Creating tasks, capturing thoughts, and asking quick questions are the primary v
 
 **Success looks like:** The user can interact with Bede while driving or doing chores, without reaching for their phone to type.
 
-### R9. Memory and continuity
+### R8. Memory and continuity
 
 **Bede must remember what matters across conversations and over time.**
 
@@ -146,6 +132,20 @@ What Bede remembers must be transparent — The user should be able to see and e
 When Bede gets something wrong based on its memory, The user must be able to correct it, and the correction must stick. Bede must not repeat a corrected mistake.
 
 **Success looks like:** Bede feels like it knows the user — not because it's guessing, but because it genuinely remembers past conversations, corrections, and context. The user never has to re-explain something they've already told Bede.
+
+### R9. Deal and price monitoring
+
+**I want deals and prices monitored on things I care about.**
+
+Bede must track prices and availability for products and events the user specifies. Categories include clothing, household staples, outdoor gear, event tickets, and whatever the user adds in future. The user defines what to watch, what retailers to check, and what constitutes a deal worth reporting.
+
+Monitoring must run on a configurable schedule. Reports should only surface when something actionable has changed — a price drop, a restock, a new event announced. No-change reports are noise.
+
+Bede must be able to browse the web to check prices and availability, since many retailers don't offer APIs.
+
+**Success looks like:** The user gets timely alerts about deals they care about without manually checking websites.
+
+**Measurable indicator:** Price alerts are delivered within 24 hours of a price change on a monitored item.
 
 ---
 
@@ -169,7 +169,7 @@ The system must use a Claude subscription (flat monthly cost), not per-token API
 
 The interface must be usable from an iPhone using only apps available from the App Store, with no custom app development or App Store deployment required. Server-side setup should be achievable in under an hour for someone with the user's technical skills.
 
-Text is the primary interaction mode. Voice is secondary (R8).
+Text is the primary interaction mode. Voice is secondary (R7).
 
 ### C5. File-based knowledge
 
@@ -253,7 +253,7 @@ Bede's value depends on having context about the user's life. These are the cate
 ### Conversation history
 - Bede's own prior conversations with the user
 - Prior corrections the user has made to Bede's behaviour or interpretations
-- Supports R1 (pattern tracking), R2 (accountability continuity), R7 (multi-turn), R9 (memory)
+- Supports R1 (pattern tracking), R2 (accountability continuity), R6 (multi-turn), R8 (memory)
 - Source: Bede's own conversation logs
 
 ### Data freshness expectations
@@ -301,8 +301,8 @@ These apply across all functional requirements.
 - Conversation history must be reviewable.
 
 ### Responsiveness
-- Text conversations (R7): Bede should respond within 30 seconds. Longer delays should show a "thinking" indicator.
-- Voice interactions (R8): same latency tolerance as text — walkie-talkie style, not real-time.
+- Text conversations (R6): Bede should respond within 30 seconds. Longer delays should show a "thinking" indicator.
+- Voice interactions (R7): same latency tolerance as text — walkie-talkie style, not real-time.
 - Scheduled tasks: no hard latency requirement, but must complete within a reasonable window (minutes, not hours).
 
 ### Extensibility
@@ -352,21 +352,24 @@ R3 (Stay current) → R5 (Knowledge base)
 R4 (Day planning) ← all data inputs
   Planning requires the broadest view: calendar, email, weather, tasks, health, goals.
 
-R7 (Conversational) ← all data inputs + R5 (Knowledge base)
+R6 (Conversational) ← all data inputs + R5 (Knowledge base)
   The conversational assistant is most valuable when it has full context.
 
-R8 (Voice) → R4 (Day planning), R5 (Knowledge base)
+R7 (Voice) → R4 (Day planning), R5 (Knowledge base)
   Voice enables quick task creation and thought capture on the go.
-  Voice is an alternative I/O mode for R7 in hands-free situations.
+  Voice is an alternative I/O mode for R6 in hands-free situations.
 
-R9 (Memory) ← R1, R2, R5, R7
+R8 (Memory) ← R1, R2, R5, R6
   Memory is foundational infrastructure. R1 needs pattern history.
   R2 needs goal tracking continuity. R5 needs to be searchable.
-  R7 needs multi-turn and cross-conversation context.
+  R6 needs multi-turn and cross-conversation context.
+
+R9 (Deal monitoring) — standalone
+  Loosely connected: deals may surface in R4 briefings. Otherwise independent.
 
 Implementation dependency note:
   R1 and R2 are highest *value* priority, but R4 (planning), R5 (knowledge
-  base), and R9 (memory) are foundational *infrastructure* that R1 and R2
+  base), and R8 (memory) are foundational *infrastructure* that R1 and R2
   depend on. A design must address this — either build infrastructure first,
   or deliver R1/R2 in reduced form initially and enhance as infrastructure
   matures.

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -77,7 +77,7 @@ If the user does not respond, the fallback behaviour in C7 applies.
 
 **Success looks like:** The user starts each day and week knowing exactly what's ahead, with no unprocessed email creating background anxiety.
 
-**Measurable indicator:** The user receives a day briefing before their day starts on 90%+ of weekdays.
+**Measurable indicator:** The user receives a day briefing (interactive or fallback) before their day starts on 90%+ of weekdays.
 
 ### R5. Personal knowledge base
 
@@ -93,7 +93,7 @@ The knowledge base must be stored as files the user owns and controls (Markdown 
 
 **Success looks like:** the user's notes are useful because they're findable, and growing because capture is effortless.
 
-**Measurable indicator:** The user can capture a thought in under 10 seconds (voice or text). Bede can answer a question using vault content when relevant notes exist.
+**Measurable indicator:** The user can capture a thought in under 10 seconds of effort (time from intent to message sent, not including Bede's response time). Bede can answer a question using vault content when relevant notes exist.
 
 ### R6. Conversational assistant
 
@@ -117,7 +117,7 @@ Bede must support voice input and voice output as a secondary interaction mode. 
 
 Voice must support the same capabilities as text — it's an alternative input/output mode, not a separate feature set. If the user can ask it in text, they can ask it by voice.
 
-Creating tasks, capturing thoughts, and asking quick questions are the primary voice use cases.
+Creating tasks, capturing thoughts, and asking quick questions are the primary voice use cases. When voice input cannot be understood, Bede must indicate the failure clearly. No message should be silently lost. The user must always be able to fall back to text.
 
 **Success looks like:** The user can interact with Bede while driving or doing chores, without reaching for their phone to type.
 
@@ -277,6 +277,9 @@ Not all data needs to arrive in real-time. Approximate expectations:
 
 These apply across all functional requirements.
 
+### Onboarding
+- Bede must build its understanding of the user progressively through data observation and natural conversation. There is no formal onboarding process. Bede starts with whatever data is available and fills gaps by asking questions naturally as they become relevant. Bede must be useful from day one with incomplete knowledge, improving as it learns more.
+
 ### Temporal awareness
 - Bede must always know the current date, time, and the user's timezone. All references to "today", "this week", "tomorrow" must resolve correctly. Scheduled tasks must fire at the right local time.
 
@@ -289,6 +292,7 @@ These apply across all functional requirements.
 ### Reliability
 - Individual component failures must not take down the entire system. If one data source is unavailable, Bede must still function with the data it has.
 - Failures must be surfaced to the user, not swallowed silently.
+- When a data source is unavailable, Bede must tell the user what's missing and proceed with what it has, rather than blocking or producing incomplete output silently.
 - The system must recover gracefully from restarts without data loss.
 - If the underlying language model is unavailable, Bede should queue incoming messages and process them when service resumes rather than dropping them silently.
 
@@ -296,6 +300,7 @@ These apply across all functional requirements.
 - The user must be able to change Bede's personality, tone, and boundaries.
 - Scheduled tasks, monitored items, interest topics, and goal definitions must all be editable by the user without code changes.
 - The user must be able to make routine configuration changes (tone, schedules, monitored items, corrections) through conversation with Bede, not only by editing files. When the user requests a change, Bede updates the underlying config files on their behalf — conversation is the input method, files are the storage.
+- Specific thresholds and cadences mentioned in requirements (e.g., retry counts, detection windows, gap thresholds) are defaults, not fixed contracts. All should be configurable.
 - Configuration should be stored as human-readable files, not in databases or admin UIs.
 
 ### Auditability
@@ -342,8 +347,7 @@ Requirements are not independent — they share data, reinforce each other, and 
 
 ```
 R1 (Mental health) ←→ R2 (Goal accountability)
-  Poor mental health causes goal drift; goal drift worsens mental health.
-  Share data: sleep, activity, screen time, media consumption, location.
+  Bidirectional — share data signals and reinforce each other.
 
 R2 (Goal accountability) ← R4 (Day planning)
   Planning sets intentions; accountability measures follow-through.

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -11,7 +11,9 @@ This document defines what Bede must do and the constraints it must operate with
 
 ## 1. What is Bede?
 
-Bede is a personal assistant for one person: Joe Radford. It knows about Joe's health, activity, location, calendar, email, screen time, goals, and knowledge base. It uses this context to coach, inform, remind, and assist — proactively on a schedule and reactively on demand.
+Bede is a personal assistant for one person: Joe Radford ("Joe" throughout this document). It knows about Joe's health, activity, location, calendar, email, screen time, goals, and knowledge base. It uses this context to coach, inform, remind, and assist — proactively on a schedule and reactively on demand.
+
+Bede is powered by Claude (Anthropic's large language model) via a subscription. This is a pragmatic constraint — Claude is the reasoning engine, but Bede is not a thin wrapper around it. Bede is the product; Claude is a dependency.
 
 ---
 
@@ -31,6 +33,8 @@ The coaching relationship must be configurable — Joe controls the tone, the bo
 
 **Success looks like:** Joe feels like someone is genuinely watching out for him and will say something honest when patterns emerge — not just echoing data back.
 
+**Measurable indicator:** Bede surfaces a concern about a negative pattern within 48 hours of the pattern emerging (e.g., 3 consecutive poor sleeps flagged by day 4).
+
 ### R2. Goal accountability
 
 **I want to be held accountable to my personal and professional goals.**
@@ -43,6 +47,8 @@ This is closely linked to R1 — poor mental health often causes goal drift, and
 
 **Success looks like:** Joe can't quietly let a goal slide for two weeks without Bede noticing and raising it.
 
+**Measurable indicator:** No active goal goes unmentioned for more than 14 days without progress.
+
 ### R3. Stay current without effort
 
 **I want to stay current in my professional and personal interests without having to go looking.**
@@ -53,15 +59,21 @@ The sources, topics, and delivery cadence must be configurable by Joe. Bede must
 
 **Success looks like:** Joe learns about things that matter to him without opening a browser to go looking.
 
+**Measurable indicator:** Joe receives at least one curated content delivery per configured topic per week.
+
 ### R4. Day and week planning
 
 **I want to know what my day and week look like before they start — including emails triaged into tasks, events, or dismissed.**
 
-Bede must prepare a view of the upcoming day (and week, at appropriate cadence) that includes: calendar events, weather, relevant reminders, and any actions extracted from email. Email triage follows a strict pattern: each email becomes a task, becomes an event, or is dismissed as requiring no action.
+Bede must prepare a view of the upcoming day (and week, at appropriate cadence) that includes: calendar events, weather, air quality, relevant reminders and tasks, and any actions extracted from email. Email triage follows a strict pattern: each email becomes a task, becomes an event, or is dismissed as requiring no action. Bede proposes the classification; Joe confirms or corrects.
 
 This must be delivered proactively before the day/week starts, not on demand. The delivery must be interactive — Bede asks questions, Joe provides input, then Bede delivers the final view. Joe must be able to correct, reprioritise, or add items during the interaction.
 
+If Joe does not respond to the interactive prompt, Bede retries up to three times total. If there is still no response, Bede sends a non-interactive version (best-effort summary without Joe's input) so the information is not lost entirely.
+
 **Success looks like:** Joe starts each day and week knowing exactly what's ahead, with no unprocessed email creating background anxiety.
+
+**Measurable indicator:** Joe receives a day briefing before his day starts on 90%+ of weekdays.
 
 ### R5. Personal knowledge base
 
@@ -69,13 +81,15 @@ This must be delivered proactively before the day/week starts, not on demand. Th
 
 Bede must integrate with Joe's personal knowledge base (currently an Obsidian vault organised using the PARA method). It must be able to read from and write to the knowledge base. Writing includes: journal entries, meeting notes, captured ideas, task outcomes, and any other structured or unstructured content Joe asks it to record.
 
-"Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should handle the organisation.
+"Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should suggest where to file things and how to organise them, but Joe makes the final decision. Bede does not file autonomously.
 
 "Easy to search" means Joe can ask Bede a question and get an answer that draws on his own notes, not just the AI's training data. The knowledge base must be the first place Bede looks for personal context.
 
 The knowledge base must be stored as files Joe owns and controls (Markdown preferred). It must be accessible from multiple devices (Mac, iPhone) and must not depend on any single vendor's sync service for its integrity.
 
 **Success looks like:** Joe's notes are useful because they're findable, and growing because capture is effortless.
+
+**Measurable indicator:** Joe can capture a thought in under 10 seconds (voice or text). Bede can answer a question using vault content when relevant notes exist.
 
 ### R6. Deal and price monitoring
 
@@ -89,6 +103,8 @@ Bede must be able to browse the web to check prices and availability, since many
 
 **Success looks like:** Joe gets timely alerts about deals he cares about without manually checking websites.
 
+**Measurable indicator:** Price alerts are delivered within 24 hours of a price change on a monitored item.
+
 ### R7. Conversational assistant
 
 **I want a conversational assistant I can ask anything, with full context on my life.**
@@ -100,6 +116,8 @@ Multi-turn conversations must be supported — Bede must remember what was discu
 This must not be limited to any specific domain. If Joe asks about cooking, travel planning, or how to fix a shelf, Bede should help.
 
 **Success looks like:** Joe uses Bede instead of a generic chat assistant because the answers are better — they account for his schedule, his health, his goals, and his history.
+
+**Measurable indicator:** Bede incorporates personal context (calendar, health, goals, or vault) in responses where relevant, without Joe having to ask for it.
 
 ### R8. Voice interaction
 
@@ -113,6 +131,22 @@ Creating tasks, capturing thoughts, and asking quick questions are the primary v
 
 **Success looks like:** Joe can interact with Bede while driving or doing chores, without reaching for his phone to type.
 
+### R9. Memory and continuity
+
+**Bede must remember what matters across conversations and over time.**
+
+Bede must maintain context beyond a single conversation. This includes:
+
+- **Within a conversation:** multi-turn context so Bede doesn't forget what was just discussed.
+- **Across conversations:** Bede must remember significant facts, preferences, corrections, and commitments Joe has made, even days or weeks later. If Joe says "I'm training for a half marathon" in March, Bede should still know that in June.
+- **Pattern recognition over time:** R1 (coaching) and R2 (accountability) require Bede to detect trends across days and weeks — sleep patterns, exercise consistency, goal progress. This requires access to historical data, not just today's snapshot.
+
+What Bede remembers must be transparent — Joe should be able to see and edit what Bede has stored about him. Bede must not silently build an internal model Joe can't inspect.
+
+When Bede gets something wrong based on its memory, Joe must be able to correct it, and the correction must stick. Bede must not repeat a corrected mistake.
+
+**Success looks like:** Bede feels like it knows Joe — not because it's guessing, but because it genuinely remembers past conversations, corrections, and context. Joe never has to re-explain something he's already told Bede.
+
 ---
 
 ## 3. Constraints
@@ -121,7 +155,7 @@ These are non-negotiable boundaries the system must operate within.
 
 ### C1. Own hardware
 
-The system must run on hardware Joe owns and controls, in his home. No cloud-hosted compute for the assistant itself. The server runs Linux or Windows (macOS would be ideal but is not in budget). Cloud services may be used for specific functions (e.g., AI inference, DNS, email APIs) but the assistant's core logic, data, and state must reside on Joe's hardware.
+The system must run on hardware Joe owns and controls, in his home. No cloud-hosted compute for the assistant itself. The server runs Linux or Windows. Cloud services may be used for specific functions (e.g., AI inference, DNS, email APIs) but the assistant's core logic, data, and state must reside on Joe's hardware.
 
 ### C2. Data sovereignty
 
@@ -133,7 +167,7 @@ The system must use a Claude subscription (flat monthly cost), not per-token API
 
 ### C4. Minimal-setup interface
 
-The interface must be easy to set up on Joe's server hardware and on an iPhone. "Easy" means: no custom app development, no App Store deployment, no complex client-side configuration. The interface should use existing apps or protocols that work on iPhone out of the box.
+The interface must be usable from an iPhone using only apps available from the App Store, with no custom app development or App Store deployment required. Server-side setup should be achievable in under an hour for someone with Joe's technical skills.
 
 Text is the primary interaction mode. Voice is secondary (R8).
 
@@ -143,11 +177,13 @@ The knowledge base must be stored as Markdown files that Joe owns. It must be ed
 
 ### C6. Maintenance budget
 
-The system must be stable enough to run unattended on weeknights. Maintenance and feature work happens on weekends (target: a couple of hours). The system must not require regular firefighting or manual intervention to keep running. When things break, failures must be visible — not silent.
+The system must run unattended on weeknights without manual intervention. Maintenance and feature work happens on weekends (target: a couple of hours). The system must not require more than one manual intervention per week on average. When things break, failures must be visible — not silent.
 
 ### C7. Scheduled interaction style
 
-Scheduled outputs (briefings, coaching check-ins, reflections) must be interactive: Bede initiates, asks Joe questions, Joe responds, then Bede produces the output. This is not optional — read-only delivery or "reply if you want" delivery does not meet the requirement.
+Scheduled outputs (briefings, coaching check-ins, reflections) must be interactive: Bede initiates, asks Joe questions, Joe responds, then Bede produces the output. This is the preferred mode — read-only delivery is a fallback, not the default.
+
+If Joe does not respond, Bede retries up to three times total. After three unanswered attempts, Bede sends a non-interactive version (best-effort output without Joe's input). The information must not be lost simply because Joe was unavailable.
 
 ---
 
@@ -169,9 +205,10 @@ Bede's value depends on having context about Joe's life. These are the categorie
 - Clustered into meaningful places (home, work, gym, etc.)
 - Source: iPhone location tracking
 
-### Screen time
+### Screen time and browsing history
 - App usage duration by app (Mac and iPhone)
 - Web domain usage duration
+- Safari browsing history (URLs, not just domains) — useful for R2 (what Joe actually reads) and R3 (interest tracking)
 - Source: macOS and iOS system data
 
 ### Calendar
@@ -210,8 +247,30 @@ Bede's value depends on having context about Joe's life. These are the categorie
 - Source: defined by Joe (not necessarily in the knowledge base — could be configured separately)
 
 ### Browsing
-- Ability to visit web pages and extract information (for deal monitoring, interest curation)
+- Ability to obtain information from websites regardless of whether they offer structured APIs (for deal monitoring, interest curation)
 - Source: the open web
+
+### Conversation history
+- Bede's own prior conversations with Joe
+- Prior corrections Joe has made to Bede's behaviour or interpretations
+- Supports R1 (pattern tracking), R2 (accountability continuity), R7 (multi-turn), R9 (memory)
+- Source: Bede's own conversation logs
+
+### Data freshness expectations
+
+Not all data needs to arrive in real-time. Approximate expectations:
+
+| Category | Freshness | Rationale |
+|----------|-----------|-----------|
+| Calendar, email, tasks | Near real-time (minutes) | Day planning needs current state |
+| Location | Near real-time when queried | "Where am I?" must be accurate now |
+| Weather and air quality | Hourly | Forecasts don't change faster |
+| Health (sleep, activity, HR) | Daily | Collected overnight or end-of-day |
+| Screen time, browsing history | Daily | Batch collection is sufficient |
+| Media consumption | Daily | Batch collection is sufficient |
+| Knowledge base | Minutes | Captures should appear quickly |
+| Conversation history | Immediate | Must be available within the same session |
+| Goals and schedule | On change | Only updates when Joe edits them |
 
 ---
 
@@ -226,9 +285,10 @@ These apply across all functional requirements.
 - Secrets and credentials must never be committed to version control.
 
 ### Reliability
-- Individual component failures must not take down the entire system.
+- Individual component failures must not take down the entire system. If one data source is unavailable, Bede must still function with the data it has.
 - Failures must be surfaced to Joe, not swallowed silently.
 - The system must recover gracefully from restarts without data loss.
+- If the underlying language model is unavailable, Bede should queue incoming messages and process them when service resumes rather than dropping them silently.
 
 ### Configurability
 - Joe must be able to change Bede's personality, tone, and boundaries.
@@ -240,9 +300,24 @@ These apply across all functional requirements.
 - Scheduled task executions must be logged with enough detail to diagnose failures.
 - Conversation history must be reviewable.
 
+### Responsiveness
+- Text conversations (R7): Bede should respond within 30 seconds. Longer delays should show a "thinking" indicator.
+- Voice interactions (R8): same latency tolerance as text — walkie-talkie style, not real-time.
+- Scheduled tasks: no hard latency requirement, but must complete within a reasonable window (minutes, not hours).
+
 ### Extensibility
 - Adding new data sources, new scheduled tasks, or new capabilities should not require rewriting existing functionality.
 - The system should be modular enough that components can be added, removed, or replaced independently.
+
+### Backup and recovery
+- Joe must be able to back up the entire system (data, configuration, state) and restore it on new hardware.
+- The backup process should be simple enough to automate (e.g., a single directory or a script).
+- Given that this runs on home hardware, hardware failure is a realistic scenario — recovery must be documented and tested.
+
+### Data retention
+- Operational data (logs, raw data exports, task execution records) should have a configurable retention period. It must not grow unboundedly.
+- Conversation history and knowledge base content should be retained indefinitely unless Joe explicitly deletes it.
+- The system should make it easy to see how much storage is being used and by what.
 
 ---
 
@@ -283,4 +358,16 @@ R7 (Conversational) ← all data inputs + R5 (Knowledge base)
 R8 (Voice) → R4 (Day planning), R5 (Knowledge base)
   Voice enables quick task creation and thought capture on the go.
   Voice is an alternative I/O mode for R7 in hands-free situations.
+
+R9 (Memory) ← R1, R2, R5, R7
+  Memory is foundational infrastructure. R1 needs pattern history.
+  R2 needs goal tracking continuity. R5 needs to be searchable.
+  R7 needs multi-turn and cross-conversation context.
+
+Implementation dependency note:
+  R1 and R2 are highest *value* priority, but R4 (planning), R5 (knowledge
+  base), and R9 (memory) are foundational *infrastructure* that R1 and R2
+  depend on. A design must address this — either build infrastructure first,
+  or deliver R1/R2 in reduced form initially and enhance as infrastructure
+  matures.
 ```

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -11,7 +11,7 @@ This document defines what Bede must do and the constraints it must operate with
 
 ## 1. What is Bede?
 
-Bede is a personal assistant for one person: Joe Radford ("Joe" throughout this document). It knows about Joe's health, activity, location, calendar, email, screen time, goals, and knowledge base. It uses this context to coach, inform, remind, and assist — proactively on a schedule and reactively on demand.
+Bede is a personal assistant for a single user. It knows about the user's health, activity, location, calendar, email, screen time, goals, and knowledge base. It uses this context to coach, inform, remind, and assist — proactively on a schedule and reactively on demand.
 
 Bede is powered by Claude (Anthropic's large language model) via a subscription. This is a pragmatic constraint — Claude is the reasoning engine, but Bede is not a thin wrapper around it. Bede is the product; Claude is a dependency.
 
@@ -27,11 +27,11 @@ Requirements are listed in priority order. Each requirement stands on its own �
 
 Bede must have access to signals relevant to mental health: sleep quality and duration, physical activity, medication adherence, mood indicators, and behavioural patterns (e.g., social isolation, routine disruption). It must surface concerns proactively and honestly — not wait to be asked. It must track patterns over time, not just react to single data points. It must be direct without being clinical, and supportive without being patronising.
 
-Coaching means ongoing, not reactive. Bede should check in regularly, notice when things are slipping before Joe does, and connect dots across days and weeks. A single bad night's sleep is not a concern; three in a row alongside dropping exercise is.
+Coaching means ongoing, not reactive. Bede should check in regularly, notice when things are slipping before the user does, and connect dots across days and weeks. A single bad night's sleep is not a concern; three in a row alongside dropping exercise is.
 
-The coaching relationship must be configurable — Joe controls the tone, the boundaries, and what topics are in scope. If Joe says "back off on this topic," Bede must respect that immediately and durably.
+The coaching relationship must be configurable — The user controls the tone, the boundaries, and what topics are in scope. If the user says "back off on this topic," Bede must respect that immediately and durably.
 
-**Success looks like:** Joe feels like someone is genuinely watching out for him and will say something honest when patterns emerge — not just echoing data back.
+**Success looks like:** The user feels like someone is genuinely watching out for him and will say something honest when patterns emerge — not just echoing data back.
 
 **Measurable indicator:** Bede surfaces a concern about a negative pattern within 48 hours of the pattern emerging (e.g., 3 consecutive poor sleeps flagged by day 4).
 
@@ -39,13 +39,13 @@ The coaching relationship must be configurable — Joe controls the tone, the bo
 
 **I want to be held accountable to my personal and professional goals.**
 
-Bede must know Joe's current goals (professional certifications, hobbies like camping/piano/reading, fitness targets, career direction) and track progress toward them. It must notice when effort is drifting — too much mindless device time, skipped practice sessions, stalled projects — and call it out.
+Bede must know the user's current goals (professional certifications, hobbies like camping/piano/reading, fitness targets, career direction) and track progress toward them. It must notice when effort is drifting — too much mindless device time, skipped practice sessions, stalled projects — and call it out.
 
-Accountability means measuring reality against intention. Bede must know what Joe said he would do (goals, weekly schedule) and what he actually did (screen time, media consumption, activity, location, calendar, task completion, vault edits). The gap between those is what matters.
+Accountability means measuring reality against intention. Bede must know what the user said he would do (goals, weekly schedule) and what he actually did (screen time, media consumption, activity, location, calendar, task completion, vault edits). The gap between those is what matters.
 
 This is closely linked to R1 — poor mental health often causes goal drift, and goal drift often worsens mental health. Bede must understand this connection and not treat them as independent.
 
-**Success looks like:** Joe can't quietly let a goal slide for two weeks without Bede noticing and raising it.
+**Success looks like:** The user can't quietly let a goal slide for two weeks without Bede noticing and raising it.
 
 **Measurable indicator:** No active goal goes unmentioned for more than 14 days without progress.
 
@@ -53,55 +53,55 @@ This is closely linked to R1 — poor mental health often causes goal drift, and
 
 **I want to stay current in my professional and personal interests without having to go looking.**
 
-Bede must curate and deliver relevant content from Joe's areas of interest — professional (software engineering, AI, cloud) and personal (music, camping, whatever Joe defines). Joe should not have to seek out this information himself; Bede should bring it to him in a digestible format.
+Bede must curate and deliver relevant content from the user's areas of interest — professional (software engineering, AI, cloud) and personal (music, camping, whatever The user defines). The user should not have to seek out this information himself; Bede should bring it to him in a digestible format.
 
-The sources, topics, and delivery cadence must be configurable by Joe. Bede must be able to distinguish signal from noise — a curated summary is valuable, a firehose is not.
+The sources, topics, and delivery cadence must be configurable by the user. Bede must be able to distinguish signal from noise — a curated summary is valuable, a firehose is not.
 
-**Success looks like:** Joe learns about things that matter to him without opening a browser to go looking.
+**Success looks like:** The user learns about things that matter to him without opening a browser to go looking.
 
-**Measurable indicator:** Joe receives at least one curated content delivery per configured topic per week.
+**Measurable indicator:** The user receives at least one curated content delivery per configured topic per week.
 
 ### R4. Day and week planning
 
 **I want to know what my day and week look like before they start — including emails triaged into tasks, events, or dismissed.**
 
-Bede must prepare a view of the upcoming day (and week, at appropriate cadence) that includes: calendar events, weather, air quality, relevant reminders and tasks, and any actions extracted from email. Email triage follows a strict pattern: each email becomes a task, becomes an event, or is dismissed as requiring no action. Bede proposes the classification; Joe confirms or corrects.
+Bede must prepare a view of the upcoming day (and week, at appropriate cadence) that includes: calendar events, weather, air quality, relevant reminders and tasks, and any actions extracted from email. Email triage follows a strict pattern: each email becomes a task, becomes an event, or is dismissed as requiring no action. Bede proposes the classification; the user confirms or corrects.
 
-This must be delivered proactively before the day/week starts, not on demand. The delivery must be interactive — Bede asks questions, Joe provides input, then Bede delivers the final view. Joe must be able to correct, reprioritise, or add items during the interaction.
+This must be delivered proactively before the day/week starts, not on demand. The delivery must be interactive — Bede asks questions, the user provides input, then Bede delivers the final view. The user must be able to correct, reprioritise, or add items during the interaction.
 
-If Joe does not respond to the interactive prompt, Bede retries up to three times total. If there is still no response, Bede sends a non-interactive version (best-effort summary without Joe's input) so the information is not lost entirely.
+If the user does not respond to the interactive prompt, Bede retries up to three times total. If there is still no response, Bede sends a non-interactive version (best-effort summary without the user's input) so the information is not lost entirely.
 
-**Success looks like:** Joe starts each day and week knowing exactly what's ahead, with no unprocessed email creating background anxiety.
+**Success looks like:** The user starts each day and week knowing exactly what's ahead, with no unprocessed email creating background anxiety.
 
-**Measurable indicator:** Joe receives a day briefing before his day starts on 90%+ of weekdays.
+**Measurable indicator:** The user receives a day briefing before his day starts on 90%+ of weekdays.
 
 ### R5. Personal knowledge base
 
 **I want my personal knowledge base to grow naturally and be easy to search.**
 
-Bede must integrate with Joe's personal knowledge base (currently an Obsidian vault organised using the PARA method). It must be able to read from and write to the knowledge base. Writing includes: journal entries, meeting notes, captured ideas, task outcomes, and any other structured or unstructured content Joe asks it to record.
+Bede must integrate with the user's personal knowledge base (currently an Obsidian vault organised using the PARA method). It must be able to read from and write to the knowledge base. Writing includes: journal entries, meeting notes, captured ideas, task outcomes, and any other structured or unstructured content the user asks it to record.
 
-"Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should suggest where to file things and how to organise them, but Joe makes the final decision. Bede does not file autonomously.
+"Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should suggest where to file things and how to organise them, but the user makes the final decision. Bede does not file autonomously.
 
-"Easy to search" means Joe can ask Bede a question and get an answer that draws on his own notes, not just the AI's training data. The knowledge base must be the first place Bede looks for personal context.
+"Easy to search" means the user can ask Bede a question and get an answer that draws on his own notes, not just the AI's training data. The knowledge base must be the first place Bede looks for personal context.
 
-The knowledge base must be stored as files Joe owns and controls (Markdown preferred). It must be accessible from multiple devices (Mac, iPhone) and must not depend on any single vendor's sync service for its integrity.
+The knowledge base must be stored as files the user owns and controls (Markdown preferred). It must be accessible from multiple devices (Mac, iPhone) and must not depend on any single vendor's sync service for its integrity.
 
-**Success looks like:** Joe's notes are useful because they're findable, and growing because capture is effortless.
+**Success looks like:** the user's notes are useful because they're findable, and growing because capture is effortless.
 
-**Measurable indicator:** Joe can capture a thought in under 10 seconds (voice or text). Bede can answer a question using vault content when relevant notes exist.
+**Measurable indicator:** The user can capture a thought in under 10 seconds (voice or text). Bede can answer a question using vault content when relevant notes exist.
 
 ### R6. Deal and price monitoring
 
 **I want deals and prices monitored on things I care about.**
 
-Bede must track prices and availability for products and events Joe specifies. Categories include clothing, household staples, outdoor gear, event tickets, and whatever Joe adds in future. Joe defines what to watch, what retailers to check, and what constitutes a deal worth reporting.
+Bede must track prices and availability for products and events the user specifies. Categories include clothing, household staples, outdoor gear, event tickets, and whatever the user adds in future. The user defines what to watch, what retailers to check, and what constitutes a deal worth reporting.
 
 Monitoring must run on a configurable schedule. Reports should only surface when something actionable has changed — a price drop, a restock, a new event announced. No-change reports are noise.
 
 Bede must be able to browse the web to check prices and availability, since many retailers don't offer APIs.
 
-**Success looks like:** Joe gets timely alerts about deals he cares about without manually checking websites.
+**Success looks like:** The user gets timely alerts about deals he cares about without manually checking websites.
 
 **Measurable indicator:** Price alerts are delivered within 24 hours of a price change on a monitored item.
 
@@ -113,23 +113,23 @@ Bede must be available for ad-hoc questions and tasks at any time. This is the g
 
 Multi-turn conversations must be supported — Bede must remember what was discussed earlier in the same conversation, not treat every message as a fresh start.
 
-This must not be limited to any specific domain. If Joe asks about cooking, travel planning, or how to fix a shelf, Bede should help.
+This must not be limited to any specific domain. If the user asks about cooking, travel planning, or how to fix a shelf, Bede should help.
 
-**Success looks like:** Joe uses Bede instead of a generic chat assistant because the answers are better — they account for his schedule, his health, his goals, and his history.
+**Success looks like:** The user uses Bede instead of a generic chat assistant because the answers are better — they account for his schedule, his health, his goals, and his history.
 
-**Measurable indicator:** Bede incorporates personal context (calendar, health, goals, or vault) in responses where relevant, without Joe having to ask for it.
+**Measurable indicator:** Bede incorporates personal context (calendar, health, goals, or vault) in responses where relevant, without the user having to ask for it.
 
 ### R8. Voice interaction
 
 **I want to talk to Bede by voice, and have Bede talk back — especially on the go.**
 
-Bede must support voice input and voice output as a secondary interaction mode. The primary use case is hands-free situations: driving, walking, cooking. Joe speaks a message, Bede responds with audio. Walkie-talkie style (speak, wait, receive response) is acceptable — real-time phone-call-style conversation is not required.
+Bede must support voice input and voice output as a secondary interaction mode. The primary use case is hands-free situations: driving, walking, cooking. The user speaks a message, Bede responds with audio. Walkie-talkie style (speak, wait, receive response) is acceptable — real-time phone-call-style conversation is not required.
 
-Voice must support the same capabilities as text — it's an alternative input/output mode, not a separate feature set. If Joe can ask it in text, he can ask it by voice.
+Voice must support the same capabilities as text — it's an alternative input/output mode, not a separate feature set. If the user can ask it in text, he can ask it by voice.
 
 Creating tasks, capturing thoughts, and asking quick questions are the primary voice use cases.
 
-**Success looks like:** Joe can interact with Bede while driving or doing chores, without reaching for his phone to type.
+**Success looks like:** The user can interact with Bede while driving or doing chores, without reaching for his phone to type.
 
 ### R9. Memory and continuity
 
@@ -138,14 +138,14 @@ Creating tasks, capturing thoughts, and asking quick questions are the primary v
 Bede must maintain context beyond a single conversation. This includes:
 
 - **Within a conversation:** multi-turn context so Bede doesn't forget what was just discussed.
-- **Across conversations:** Bede must remember significant facts, preferences, corrections, and commitments Joe has made, even days or weeks later. If Joe says "I'm training for a half marathon" in March, Bede should still know that in June.
+- **Across conversations:** Bede must remember significant facts, preferences, corrections, and commitments the user has made, even days or weeks later. If the user says "I'm training for a half marathon" in March, Bede should still know that in June.
 - **Pattern recognition over time:** R1 (coaching) and R2 (accountability) require Bede to detect trends across days and weeks — sleep patterns, exercise consistency, goal progress. This requires access to historical data, not just today's snapshot.
 
-What Bede remembers must be transparent — Joe should be able to see and edit what Bede has stored about him. Bede must not silently build an internal model Joe can't inspect.
+What Bede remembers must be transparent — The user should be able to see and edit what Bede has stored about them. Bede must not silently build an internal model The user can't inspect.
 
-When Bede gets something wrong based on its memory, Joe must be able to correct it, and the correction must stick. Bede must not repeat a corrected mistake.
+When Bede gets something wrong based on its memory, The user must be able to correct it, and the correction must stick. Bede must not repeat a corrected mistake.
 
-**Success looks like:** Bede feels like it knows Joe — not because it's guessing, but because it genuinely remembers past conversations, corrections, and context. Joe never has to re-explain something he's already told Bede.
+**Success looks like:** Bede feels like it knows the user — not because it's guessing, but because it genuinely remembers past conversations, corrections, and context. The user never has to re-explain something he's already told Bede.
 
 ---
 
@@ -155,11 +155,11 @@ These are non-negotiable boundaries the system must operate within.
 
 ### C1. Own hardware
 
-The system must run on hardware Joe owns and controls, in his home. No cloud-hosted compute for the assistant itself. The server runs Linux or Windows. Cloud services may be used for specific functions (e.g., AI inference, DNS, email APIs) but the assistant's core logic, data, and state must reside on Joe's hardware.
+The system must run on hardware the user owns and controls, in his home. No cloud-hosted compute for the assistant itself. The server runs Linux or Windows. Cloud services may be used for specific functions (e.g., AI inference, DNS, email APIs) but the assistant's core logic, data, and state must reside on the user's hardware.
 
 ### C2. Data sovereignty
 
-All personal data — health, location, screen time, calendar, email content, conversation history, knowledge base — must be stored on Joe's own infrastructure. Data may transit third-party services for processing (e.g., sending a prompt to Claude for inference) but must not be stored by third parties beyond what is necessary for the service to function. Joe must be able to delete all his data by deleting files on his own server.
+All personal data — health, location, screen time, calendar, email content, conversation history, knowledge base — must be stored on the user's own infrastructure. Data may transit third-party services for processing (e.g., sending a prompt to Claude for inference) but must not be stored by third parties beyond what is necessary for the service to function. The user must be able to delete all his data by deleting files on his own server.
 
 ### C3. Claude subscription
 
@@ -167,13 +167,13 @@ The system must use a Claude subscription (flat monthly cost), not per-token API
 
 ### C4. Minimal-setup interface
 
-The interface must be usable from an iPhone using only apps available from the App Store, with no custom app development or App Store deployment required. Server-side setup should be achievable in under an hour for someone with Joe's technical skills.
+The interface must be usable from an iPhone using only apps available from the App Store, with no custom app development or App Store deployment required. Server-side setup should be achievable in under an hour for someone with the user's technical skills.
 
 Text is the primary interaction mode. Voice is secondary (R8).
 
 ### C5. File-based knowledge
 
-The knowledge base must be stored as Markdown files that Joe owns. It must be editable with standard text editors and must not be locked into any proprietary format. Obsidian is the likely tool but must not be a hard dependency — the files must be usable without it.
+The knowledge base must be stored as Markdown files that the user owns. It must be editable with standard text editors and must not be locked into any proprietary format. Obsidian is the likely tool but must not be a hard dependency — the files must be usable without it.
 
 ### C6. Maintenance budget
 
@@ -181,15 +181,15 @@ The system must run unattended on weeknights without manual intervention. Mainte
 
 ### C7. Scheduled interaction style
 
-Scheduled outputs (briefings, coaching check-ins, reflections) must be interactive: Bede initiates, asks Joe questions, Joe responds, then Bede produces the output. This is the preferred mode — read-only delivery is a fallback, not the default.
+Scheduled outputs (briefings, coaching check-ins, reflections) must be interactive: Bede initiates, asks the user questions, the user responds, then Bede produces the output. This is the preferred mode — read-only delivery is a fallback, not the default.
 
-If Joe does not respond, Bede retries up to three times total. After three unanswered attempts, Bede sends a non-interactive version (best-effort output without Joe's input). The information must not be lost simply because Joe was unavailable.
+If the user does not respond, Bede retries up to three times total. After three unanswered attempts, Bede sends a non-interactive version (best-effort output without the user's input). The information must not be lost simply because the user was unavailable.
 
 ---
 
 ## 4. Data Inputs
 
-Bede's value depends on having context about Joe's life. These are the categories of data the system must be able to access. This section defines what data is needed, not how it is collected or stored.
+Bede's value depends on having context about the user's life. These are the categories of data the system must be able to access. This section defines what data is needed, not how it is collected or stored.
 
 ### Health and wellness
 - Sleep: duration, quality, bedtime/wake time
@@ -201,14 +201,14 @@ Bede's value depends on having context about Joe's life. These are the categorie
 - Source: Apple Health (iPhone/Apple Watch)
 
 ### Location
-- Where Joe has been during the day (GPS-based)
+- Where the user has been during the day (GPS-based)
 - Clustered into meaningful places (home, work, gym, etc.)
 - Source: iPhone location tracking
 
 ### Screen time and browsing history
 - App usage duration by app (Mac and iPhone)
 - Web domain usage duration
-- Safari browsing history (URLs, not just domains) — useful for R2 (what Joe actually reads) and R3 (interest tracking)
+- Safari browsing history (URLs, not just domains) — useful for R2 (what the user actually reads) and R3 (interest tracking)
 - Source: macOS and iOS system data
 
 ### Calendar
@@ -233,7 +233,7 @@ Bede's value depends on having context about Joe's life. These are the categorie
 - Source: macOS and iOS system data, streaming service history
 
 ### Weather and air quality
-- Current conditions and forecast for Joe's location
+- Current conditions and forecast for the user's location
 - Air quality index and alerts
 - Source: Bureau of Meteorology (Australia), NSW government air quality API
 
@@ -242,17 +242,17 @@ Bede's value depends on having context about Joe's life. These are the categorie
 - Source: Obsidian vault (Markdown files)
 
 ### Goals and schedule
-- Joe's current goals (professional, personal, health)
-- Joe's intended weekly schedule/routine
-- Source: defined by Joe (not necessarily in the knowledge base — could be configured separately)
+- the user's current goals (professional, personal, health)
+- the user's intended weekly schedule/routine
+- Source: defined by the user (not necessarily in the knowledge base — could be configured separately)
 
 ### Browsing
 - Ability to obtain information from websites regardless of whether they offer structured APIs (for deal monitoring, interest curation)
 - Source: the open web
 
 ### Conversation history
-- Bede's own prior conversations with Joe
-- Prior corrections Joe has made to Bede's behaviour or interpretations
+- Bede's own prior conversations with the user
+- Prior corrections the user has made to Bede's behaviour or interpretations
 - Supports R1 (pattern tracking), R2 (accountability continuity), R7 (multi-turn), R9 (memory)
 - Source: Bede's own conversation logs
 
@@ -270,7 +270,7 @@ Not all data needs to arrive in real-time. Approximate expectations:
 | Media consumption | Daily | Batch collection is sufficient |
 | Knowledge base | Minutes | Captures should appear quickly |
 | Conversation history | Immediate | Must be available within the same session |
-| Goals and schedule | On change | Only updates when Joe edits them |
+| Goals and schedule | On change | Only updates when the user edits them |
 
 ---
 
@@ -280,23 +280,23 @@ These apply across all functional requirements.
 
 ### Privacy and security
 - The system must not expose personal data to unauthorized parties.
-- External-facing endpoints must be authenticated and access-restricted to Joe's network.
-- The assistant must not be able to exfiltrate data through tool calls without Joe's awareness.
+- External-facing endpoints must be authenticated and access-restricted to the user's network.
+- The assistant must not be able to exfiltrate data through tool calls without the user's awareness.
 - Secrets and credentials must never be committed to version control.
 
 ### Reliability
 - Individual component failures must not take down the entire system. If one data source is unavailable, Bede must still function with the data it has.
-- Failures must be surfaced to Joe, not swallowed silently.
+- Failures must be surfaced to the user, not swallowed silently.
 - The system must recover gracefully from restarts without data loss.
 - If the underlying language model is unavailable, Bede should queue incoming messages and process them when service resumes rather than dropping them silently.
 
 ### Configurability
-- Joe must be able to change Bede's personality, tone, and boundaries.
-- Scheduled tasks, monitored items, interest topics, and goal definitions must all be editable by Joe without code changes.
+- The user must be able to change Bede's personality, tone, and boundaries.
+- Scheduled tasks, monitored items, interest topics, and goal definitions must all be editable by the user without code changes.
 - Configuration should be stored as human-readable files, not in databases or admin UIs.
 
 ### Auditability
-- Joe must be able to see what Bede did, when, and why.
+- The user must be able to see what Bede did, when, and why.
 - Scheduled task executions must be logged with enough detail to diagnose failures.
 - Conversation history must be reviewable.
 
@@ -310,13 +310,13 @@ These apply across all functional requirements.
 - The system should be modular enough that components can be added, removed, or replaced independently.
 
 ### Backup and recovery
-- Joe must be able to back up the entire system (data, configuration, state) and restore it on new hardware.
+- The user must be able to back up the entire system (data, configuration, state) and restore it on new hardware.
 - The backup process should be simple enough to automate (e.g., a single directory or a script).
 - Given that this runs on home hardware, hardware failure is a realistic scenario — recovery must be documented and tested.
 
 ### Data retention
 - Operational data (logs, raw data exports, task execution records) should have a configurable retention period. It must not grow unboundedly.
-- Conversation history and knowledge base content should be retained indefinitely unless Joe explicitly deletes it.
+- Conversation history and knowledge base content should be retained indefinitely unless the user explicitly deletes it.
 - The system should make it easy to see how much storage is being used and by what.
 
 ---
@@ -347,7 +347,7 @@ R2 (Goal accountability) ← R4 (Day planning)
   Tasks/reminders bridge both: R4 creates them, R2 tracks completion.
 
 R3 (Stay current) → R5 (Knowledge base)
-  Curated content should flow into the knowledge base if Joe wants to keep it.
+  Curated content should flow into the knowledge base if the user wants to keep it.
 
 R4 (Day planning) ← all data inputs
   Planning requires the broadest view: calendar, email, weather, tasks, health, goals.

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -1,0 +1,286 @@
+# Bede — Requirements Document
+
+**Version:** 1.0
+**Date:** 2026-04-29
+**Author:** Joe Radford + Claude
+**Status:** Draft — awaiting review
+
+This document defines what Bede must do and the constraints it must operate within. It is deliberately implementation-agnostic — it says nothing about architecture, technology choices, or how the requirements should be met. Design decisions belong in a separate design document.
+
+---
+
+## 1. What is Bede?
+
+Bede is a personal assistant for one person: Joe Radford. It knows about Joe's health, activity, location, calendar, email, screen time, goals, and knowledge base. It uses this context to coach, inform, remind, and assist — proactively on a schedule and reactively on demand.
+
+---
+
+## 2. Requirements
+
+Requirements are listed in priority order. Each requirement stands on its own — the system must deliver value for each independently, not only when all are working together.
+
+### R1. Mental health coaching
+
+**I want to be coached to keep my mental health issues of anxiety and depression in check.**
+
+Bede must have access to signals relevant to mental health: sleep quality and duration, physical activity, medication adherence, mood indicators, and behavioural patterns (e.g., social isolation, routine disruption). It must surface concerns proactively and honestly — not wait to be asked. It must track patterns over time, not just react to single data points. It must be direct without being clinical, and supportive without being patronising.
+
+Coaching means ongoing, not reactive. Bede should check in regularly, notice when things are slipping before Joe does, and connect dots across days and weeks. A single bad night's sleep is not a concern; three in a row alongside dropping exercise is.
+
+The coaching relationship must be configurable — Joe controls the tone, the boundaries, and what topics are in scope. If Joe says "back off on this topic," Bede must respect that immediately and durably.
+
+**Success looks like:** Joe feels like someone is genuinely watching out for him and will say something honest when patterns emerge — not just echoing data back.
+
+### R2. Goal accountability
+
+**I want to be held accountable to my personal and professional goals.**
+
+Bede must know Joe's current goals (professional certifications, hobbies like camping/piano/reading, fitness targets, career direction) and track progress toward them. It must notice when effort is drifting — too much mindless device time, skipped practice sessions, stalled projects — and call it out.
+
+Accountability means measuring reality against intention. Bede must know what Joe said he would do (goals, weekly schedule) and what he actually did (screen time, media consumption, activity, location, calendar, task completion, vault edits). The gap between those is what matters.
+
+This is closely linked to R1 — poor mental health often causes goal drift, and goal drift often worsens mental health. Bede must understand this connection and not treat them as independent.
+
+**Success looks like:** Joe can't quietly let a goal slide for two weeks without Bede noticing and raising it.
+
+### R3. Stay current without effort
+
+**I want to stay current in my professional and personal interests without having to go looking.**
+
+Bede must curate and deliver relevant content from Joe's areas of interest — professional (software engineering, AI, cloud) and personal (music, camping, whatever Joe defines). Joe should not have to seek out this information himself; Bede should bring it to him in a digestible format.
+
+The sources, topics, and delivery cadence must be configurable by Joe. Bede must be able to distinguish signal from noise — a curated summary is valuable, a firehose is not.
+
+**Success looks like:** Joe learns about things that matter to him without opening a browser to go looking.
+
+### R4. Day and week planning
+
+**I want to know what my day and week look like before they start — including emails triaged into tasks, events, or dismissed.**
+
+Bede must prepare a view of the upcoming day (and week, at appropriate cadence) that includes: calendar events, weather, relevant reminders, and any actions extracted from email. Email triage follows a strict pattern: each email becomes a task, becomes an event, or is dismissed as requiring no action.
+
+This must be delivered proactively before the day/week starts, not on demand. The delivery must be interactive — Bede asks questions, Joe provides input, then Bede delivers the final view. Joe must be able to correct, reprioritise, or add items during the interaction.
+
+**Success looks like:** Joe starts each day and week knowing exactly what's ahead, with no unprocessed email creating background anxiety.
+
+### R5. Personal knowledge base
+
+**I want my personal knowledge base to grow naturally and be easy to search.**
+
+Bede must integrate with Joe's personal knowledge base (currently an Obsidian vault organised using the PARA method). It must be able to read from and write to the knowledge base. Writing includes: journal entries, meeting notes, captured ideas, task outcomes, and any other structured or unstructured content Joe asks it to record.
+
+"Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should handle the organisation.
+
+"Easy to search" means Joe can ask Bede a question and get an answer that draws on his own notes, not just the AI's training data. The knowledge base must be the first place Bede looks for personal context.
+
+The knowledge base must be stored as files Joe owns and controls (Markdown preferred). It must be accessible from multiple devices (Mac, iPhone) and must not depend on any single vendor's sync service for its integrity.
+
+**Success looks like:** Joe's notes are useful because they're findable, and growing because capture is effortless.
+
+### R6. Deal and price monitoring
+
+**I want deals and prices monitored on things I care about.**
+
+Bede must track prices and availability for products and events Joe specifies. Categories include clothing, household staples, outdoor gear, event tickets, and whatever Joe adds in future. Joe defines what to watch, what retailers to check, and what constitutes a deal worth reporting.
+
+Monitoring must run on a configurable schedule. Reports should only surface when something actionable has changed — a price drop, a restock, a new event announced. No-change reports are noise.
+
+Bede must be able to browse the web to check prices and availability, since many retailers don't offer APIs.
+
+**Success looks like:** Joe gets timely alerts about deals he cares about without manually checking websites.
+
+### R7. Conversational assistant
+
+**I want a conversational assistant I can ask anything, with full context on my life.**
+
+Bede must be available for ad-hoc questions and tasks at any time. This is the general-purpose assistant capability — drafting messages, answering questions, brainstorming, looking things up, helping with decisions. The key differentiator from a generic assistant is that Bede has full context: calendar, health, location, goals, knowledge base, conversation history.
+
+Multi-turn conversations must be supported — Bede must remember what was discussed earlier in the same conversation, not treat every message as a fresh start.
+
+This must not be limited to any specific domain. If Joe asks about cooking, travel planning, or how to fix a shelf, Bede should help.
+
+**Success looks like:** Joe uses Bede instead of a generic chat assistant because the answers are better — they account for his schedule, his health, his goals, and his history.
+
+### R8. Voice interaction
+
+**I want to talk to Bede by voice, and have Bede talk back — especially on the go.**
+
+Bede must support voice input and voice output as a secondary interaction mode. The primary use case is hands-free situations: driving, walking, cooking. Joe speaks a message, Bede responds with audio. Walkie-talkie style (speak, wait, receive response) is acceptable — real-time phone-call-style conversation is not required.
+
+Voice must support the same capabilities as text — it's an alternative input/output mode, not a separate feature set. If Joe can ask it in text, he can ask it by voice.
+
+Creating tasks, capturing thoughts, and asking quick questions are the primary voice use cases.
+
+**Success looks like:** Joe can interact with Bede while driving or doing chores, without reaching for his phone to type.
+
+---
+
+## 3. Constraints
+
+These are non-negotiable boundaries the system must operate within.
+
+### C1. Own hardware
+
+The system must run on hardware Joe owns and controls, in his home. No cloud-hosted compute for the assistant itself. The server runs Linux or Windows (macOS would be ideal but is not in budget). Cloud services may be used for specific functions (e.g., AI inference, DNS, email APIs) but the assistant's core logic, data, and state must reside on Joe's hardware.
+
+### C2. Data sovereignty
+
+All personal data — health, location, screen time, calendar, email content, conversation history, knowledge base — must be stored on Joe's own infrastructure. Data may transit third-party services for processing (e.g., sending a prompt to Claude for inference) but must not be stored by third parties beyond what is necessary for the service to function. Joe must be able to delete all his data by deleting files on his own server.
+
+### C3. Claude subscription
+
+The system must use a Claude subscription (flat monthly cost), not per-token API billing. This constrains how the system interacts with Claude — it must use mechanisms covered by the subscription, not the commercial API.
+
+### C4. Minimal-setup interface
+
+The interface must be easy to set up on Joe's server hardware and on an iPhone. "Easy" means: no custom app development, no App Store deployment, no complex client-side configuration. The interface should use existing apps or protocols that work on iPhone out of the box.
+
+Text is the primary interaction mode. Voice is secondary (R8).
+
+### C5. File-based knowledge
+
+The knowledge base must be stored as Markdown files that Joe owns. It must be editable with standard text editors and must not be locked into any proprietary format. Obsidian is the likely tool but must not be a hard dependency — the files must be usable without it.
+
+### C6. Maintenance budget
+
+The system must be stable enough to run unattended on weeknights. Maintenance and feature work happens on weekends (target: a couple of hours). The system must not require regular firefighting or manual intervention to keep running. When things break, failures must be visible — not silent.
+
+### C7. Scheduled interaction style
+
+Scheduled outputs (briefings, coaching check-ins, reflections) must be interactive: Bede initiates, asks Joe questions, Joe responds, then Bede produces the output. This is not optional — read-only delivery or "reply if you want" delivery does not meet the requirement.
+
+---
+
+## 4. Data Inputs
+
+Bede's value depends on having context about Joe's life. These are the categories of data the system must be able to access. This section defines what data is needed, not how it is collected or stored.
+
+### Health and wellness
+- Sleep: duration, quality, bedtime/wake time
+- Physical activity: steps, exercise minutes, stand hours, active energy
+- Workouts: type, duration, intensity
+- Heart rate: resting heart rate, heart rate variability
+- Medications: adherence tracking
+- Mood/wellbeing: state of mind entries, mindfulness minutes
+- Source: Apple Health (iPhone/Apple Watch)
+
+### Location
+- Where Joe has been during the day (GPS-based)
+- Clustered into meaningful places (home, work, gym, etc.)
+- Source: iPhone location tracking
+
+### Screen time
+- App usage duration by app (Mac and iPhone)
+- Web domain usage duration
+- Source: macOS and iOS system data
+
+### Calendar
+- Events across personal calendars
+- Work calendar is not available (locked down, Bede cannot access it)
+- Source: Google Calendar
+
+### Email
+- Inbox contents for triage
+- Ability to search, read, and (with permission) send/reply
+- Source: Gmail
+
+### Reminders and tasks
+- Active reminders and tasks, and their completion status
+- Bede must be able to create tasks/reminders (e.g., captured via voice while driving)
+- Source: Google Tasks or equivalent task system
+
+### Media consumption
+- YouTube watch history
+- Podcast listening history (episodes, duration)
+- Music listening history
+- Source: macOS and iOS system data, streaming service history
+
+### Weather and air quality
+- Current conditions and forecast for Joe's location
+- Air quality index and alerts
+- Source: Bureau of Meteorology (Australia), NSW government air quality API
+
+### Knowledge base
+- All notes, journal entries, and structured files in the personal vault
+- Source: Obsidian vault (Markdown files)
+
+### Goals and schedule
+- Joe's current goals (professional, personal, health)
+- Joe's intended weekly schedule/routine
+- Source: defined by Joe (not necessarily in the knowledge base — could be configured separately)
+
+### Browsing
+- Ability to visit web pages and extract information (for deal monitoring, interest curation)
+- Source: the open web
+
+---
+
+## 5. Cross-Cutting Requirements
+
+These apply across all functional requirements.
+
+### Privacy and security
+- The system must not expose personal data to unauthorized parties.
+- External-facing endpoints must be authenticated and access-restricted to Joe's network.
+- The assistant must not be able to exfiltrate data through tool calls without Joe's awareness.
+- Secrets and credentials must never be committed to version control.
+
+### Reliability
+- Individual component failures must not take down the entire system.
+- Failures must be surfaced to Joe, not swallowed silently.
+- The system must recover gracefully from restarts without data loss.
+
+### Configurability
+- Joe must be able to change Bede's personality, tone, and boundaries.
+- Scheduled tasks, monitored items, interest topics, and goal definitions must all be editable by Joe without code changes.
+- Configuration should be stored as human-readable files, not in databases or admin UIs.
+
+### Auditability
+- Joe must be able to see what Bede did, when, and why.
+- Scheduled task executions must be logged with enough detail to diagnose failures.
+- Conversation history must be reviewable.
+
+### Extensibility
+- Adding new data sources, new scheduled tasks, or new capabilities should not require rewriting existing functionality.
+- The system should be modular enough that components can be added, removed, or replaced independently.
+
+---
+
+## 6. What This Document Does Not Cover
+
+- **Architecture and technology choices.** How the requirements are met is a design decision.
+- **Specific schedules or cadences.** When briefings run, how often coaching checks in, etc. are configuration, not requirements.
+- **UI/UX design.** How messages are formatted, what buttons exist, etc.
+- **Migration plan.** How to get from the current system to the target system.
+- **Cost analysis.** Budget for hardware, subscriptions, or services.
+
+These belong in subsequent design and planning documents.
+
+---
+
+## Appendix: Relationship Map
+
+Requirements are not independent — they share data, reinforce each other, and in some cases conflict. Key relationships:
+
+```
+R1 (Mental health) ←→ R2 (Goal accountability)
+  Poor mental health causes goal drift; goal drift worsens mental health.
+  Share data: sleep, activity, screen time, media consumption, location.
+
+R2 (Goal accountability) ← R4 (Day planning)
+  Planning sets intentions; accountability measures follow-through.
+  Tasks/reminders bridge both: R4 creates them, R2 tracks completion.
+
+R3 (Stay current) → R5 (Knowledge base)
+  Curated content should flow into the knowledge base if Joe wants to keep it.
+
+R4 (Day planning) ← all data inputs
+  Planning requires the broadest view: calendar, email, weather, tasks, health, goals.
+
+R7 (Conversational) ← all data inputs + R5 (Knowledge base)
+  The conversational assistant is most valuable when it has full context.
+
+R8 (Voice) → R4 (Day planning), R5 (Knowledge base)
+  Voice enables quick task creation and thought capture on the go.
+  Voice is an alternative I/O mode for R7 in hands-free situations.
+```

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -29,11 +29,11 @@ Bede must have access to signals relevant to mental health: sleep quality and du
 
 Coaching means ongoing, not reactive. Bede should check in regularly, notice when things are slipping before the user does, and connect dots across days and weeks. A single bad night's sleep is not a concern; three in a row alongside dropping exercise is.
 
-The coaching relationship must be configurable — The user controls the tone, the boundaries, and what topics are in scope. If the user says "back off on this topic," Bede must respect that immediately and durably.
+The coaching relationship must be configurable — the user controls the tone, the boundaries, and what topics are in scope. If the user says "back off on this topic," Bede must respect that immediately and durably.
 
 **Success looks like:** The user feels like someone is genuinely watching out for them and will say something honest when patterns emerge — not just echoing data back.
 
-**Measurable indicator:** Bede surfaces a concern about a negative pattern within 48 hours of the pattern emerging (e.g., 3 consecutive poor sleeps flagged by day 4).
+**Measurable indicator:** Bede surfaces a concern about a negative pattern within 48 hours of the pattern emerging (e.g., 3 consecutive poor sleeps flagged by day 4). What constitutes a negative pattern varies by signal and must be configurable.
 
 ### R2. Goal accountability
 
@@ -53,7 +53,7 @@ This is closely linked to R1 — poor mental health often causes goal drift, and
 
 **I want to stay current in my professional and personal interests without having to go looking.**
 
-Bede must curate and deliver relevant content from the user's areas of interest — professional (software engineering, AI, cloud) and personal (music, camping, whatever The user defines). The user should not have to seek out this information; Bede should bring it to them in a digestible format.
+Bede must curate and deliver relevant content from the user's areas of interest — professional (software engineering, AI, cloud) and personal (music, camping, whatever the user defines). The user should not have to seek out this information; Bede should bring it to them in a digestible format.
 
 The sources, topics, and delivery cadence must be configurable by the user. Bede must be able to distinguish signal from noise — a curated summary is valuable, a firehose is not.
 
@@ -69,7 +69,7 @@ Bede must prepare a view of the upcoming day (and week, at appropriate cadence) 
 
 This must be delivered proactively before the day/week starts, not on demand. The delivery must be interactive — Bede asks questions, the user provides input, then Bede delivers the final view. The user must be able to correct, reprioritise, or add items during the interaction.
 
-If the user does not respond to the interactive prompt, Bede retries up to three times total. If there is still no response, Bede sends a non-interactive version (best-effort summary without the user's input) so the information is not lost entirely.
+If the user does not respond, the fallback behaviour in C7 applies.
 
 **Success looks like:** The user starts each day and week knowing exactly what's ahead, with no unprocessed email creating background anxiety.
 
@@ -81,7 +81,7 @@ If the user does not respond to the interactive prompt, Bede retries up to three
 
 Bede must integrate with the user's personal knowledge base. It must be able to read from and write to the knowledge base. Writing includes: journal entries, meeting notes, captured ideas, task outcomes, and any other structured or unstructured content the user asks it to record.
 
-"Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should suggest where to file things and how to organise them, but the user makes the final decision. Bede does not file autonomously.
+"Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should suggest where to file things and how to organise them, but the user makes the final decision. Bede does not decide where to file content autonomously — it suggests, the user confirms.
 
 "Easy to search" means the user can ask Bede a question and get an answer that draws on their own notes, not just the model's training data. The knowledge base must be the first place Bede looks for personal context.
 
@@ -117,6 +117,8 @@ Creating tasks, capturing thoughts, and asking quick questions are the primary v
 
 **Success looks like:** The user can interact with Bede while driving or doing chores, without reaching for their phone to type.
 
+**Measurable indicator:** The user can complete a voice interaction (ask a question or capture a thought) without needing to repeat themselves or fall back to text on 90%+ of attempts.
+
 ### R8. Memory and continuity
 
 **Bede must remember what matters across conversations and over time.**
@@ -127,9 +129,9 @@ Bede must maintain context beyond a single conversation. This includes:
 - **Across conversations:** Bede must remember significant facts, preferences, corrections, and commitments the user has made, even days or weeks later. If the user says "I'm training for a half marathon" in March, Bede should still know that in June.
 - **Pattern recognition over time:** R1 (coaching) and R2 (accountability) require Bede to detect trends across days and weeks — sleep patterns, exercise consistency, goal progress. This requires access to historical data, not just today's snapshot.
 
-What Bede remembers must be transparent — The user should be able to see and edit what Bede has stored about them. Bede must not silently build an internal model The user can't inspect.
+What Bede remembers must be transparent — the user should be able to see and edit what Bede has stored about them. Bede must not silently build an internal model the user can't inspect.
 
-When Bede gets something wrong based on its memory, The user must be able to correct it, and the correction must stick. Bede must not repeat a corrected mistake.
+When Bede gets something wrong based on its memory, the user must be able to correct it, and the correction must stick. Bede must not repeat a corrected mistake.
 
 **Success looks like:** Bede feels like it knows the user — not because it's guessing, but because it genuinely remembers past conversations, corrections, and context. The user never has to re-explain something they've already told Bede.
 
@@ -163,11 +165,13 @@ All personal data — health, location, screen time, calendar, email content, co
 
 ### C3. Claude subscription
 
-The system must use a Claude subscription (flat monthly cost), not per-token API billing. This constrains how the system interacts with Claude — it must use mechanisms covered by the subscription, not the commercial API.
+The system must use a Claude subscription (flat monthly cost), not per-token API billing. The subscription provides interactive chat sessions (text in, text out) with tool-use capabilities, not batch or embedding endpoints. This constrains how the system interacts with Claude — it must use mechanisms covered by the subscription, not the commercial API.
 
 ### C4. Minimal-setup interface
 
-The interface must be usable from an iPhone using only apps available from the App Store, with no custom app development or App Store deployment required. Server-side setup should be achievable in under an hour for someone with the user's technical skills.
+The interface must be usable from an iPhone using only apps available from the App Store, with no custom app development or App Store deployment required. Server-side setup should be achievable in under an hour for someone comfortable with Docker, SSH, and Linux system administration.
+
+The interface must support push delivery — Bede must be able to reach the user without the user opening the app first.
 
 Text is the primary interaction mode. Voice is secondary (R7).
 
@@ -284,6 +288,7 @@ These apply across all functional requirements.
 ### Configurability
 - The user must be able to change Bede's personality, tone, and boundaries.
 - Scheduled tasks, monitored items, interest topics, and goal definitions must all be editable by the user without code changes.
+- The user must be able to make routine configuration changes (tone, schedules, monitored items, corrections) through conversation with Bede, not only by editing files.
 - Configuration should be stored as human-readable files, not in databases or admin UIs.
 
 ### Auditability
@@ -357,11 +362,4 @@ R8 (Memory) ← R1, R2, R5, R6
 
 R9 (Deal monitoring) — standalone
   Loosely connected: deals may surface in R4 briefings. Otherwise independent.
-
-Implementation dependency note:
-  R1 and R2 are highest *value* priority, but R4 (planning), R5 (knowledge
-  base), and R8 (memory) are foundational *infrastructure* that R1 and R2
-  depend on. A design must address this — either build infrastructure first,
-  or deliver R1/R2 in reduced form initially and enhance as infrastructure
-  matures.
 ```

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -278,6 +278,9 @@ Not all data needs to arrive in real-time. Approximate expectations:
 
 These apply across all functional requirements.
 
+### Temporal awareness
+- Bede must always know the current date, time, and the user's timezone. All references to "today", "this week", "tomorrow" must resolve correctly. Scheduled tasks must fire at the right local time.
+
 ### Privacy and security
 - The system must not expose personal data to unauthorized parties.
 - External-facing endpoints must be authenticated and access-restricted to the user's network.

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -198,63 +198,51 @@ Bede's value depends on having context about the user's life. These are the cate
 - Heart rate: resting heart rate, heart rate variability
 - Medications: adherence tracking
 - Mood/wellbeing: state of mind entries, mindfulness minutes
-- Source: Apple Health (iPhone/Apple Watch)
 
 ### Location
 - Where the user has been during the day (GPS-based)
 - Clustered into meaningful places (home, work, gym, etc.)
-- Source: iPhone location tracking
 
 ### Screen time and browsing history
-- App usage duration by app (Mac and iPhone)
+- App usage duration by app
 - Web domain usage duration
-- Safari browsing history (URLs, not just domains) — useful for R2 (what the user actually reads) and R3 (interest tracking)
-- Source: macOS and iOS system data
+- Browsing history (URLs, not just domains) — useful for R2 (what the user actually reads) and R3 (interest tracking)
 
 ### Calendar
 - Events across personal calendars
 - Work calendar is not available (locked down, Bede cannot access it)
-- Source: Google Calendar
 
 ### Email
 - Inbox contents for triage
 - Ability to search, read, and (with permission) send/reply
-- Source: Gmail
 
 ### Reminders and tasks
 - Active reminders and tasks, and their completion status
 - Bede must be able to create tasks/reminders (e.g., captured via voice while driving)
-- Source: Google Tasks or equivalent task system
 
 ### Media consumption
 - YouTube watch history
 - Podcast listening history (episodes, duration)
 - Music listening history
-- Source: macOS and iOS system data, streaming service history
 
 ### Weather and air quality
 - Current conditions and forecast for the user's location
 - Air quality index and alerts
-- Source: Bureau of Meteorology (Australia), NSW government air quality API
 
 ### Knowledge base
 - All notes, journal entries, and structured files in the personal vault
-- Source: Obsidian vault (Markdown files)
 
 ### Goals and schedule
-- the user's current goals (professional, personal, health)
-- the user's intended weekly schedule/routine
-- Source: defined by the user (not necessarily in the knowledge base — could be configured separately)
+- The user's current goals (professional, personal, health)
+- The user's intended weekly schedule/routine
 
 ### Browsing
 - Ability to obtain information from websites regardless of whether they offer structured APIs (for deal monitoring, interest curation)
-- Source: the open web
 
 ### Conversation history
 - Bede's own prior conversations with the user
 - Prior corrections the user has made to Bede's behaviour or interpretations
 - Supports R1 (pattern tracking), R2 (accountability continuity), R6 (multi-turn), R8 (memory)
-- Source: Bede's own conversation logs
 
 ### Data freshness expectations
 

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -31,7 +31,7 @@ Coaching means ongoing, not reactive. Bede should check in regularly, notice whe
 
 The coaching relationship must be configurable — The user controls the tone, the boundaries, and what topics are in scope. If the user says "back off on this topic," Bede must respect that immediately and durably.
 
-**Success looks like:** The user feels like someone is genuinely watching out for him and will say something honest when patterns emerge — not just echoing data back.
+**Success looks like:** The user feels like someone is genuinely watching out for them and will say something honest when patterns emerge — not just echoing data back.
 
 **Measurable indicator:** Bede surfaces a concern about a negative pattern within 48 hours of the pattern emerging (e.g., 3 consecutive poor sleeps flagged by day 4).
 
@@ -41,7 +41,7 @@ The coaching relationship must be configurable — The user controls the tone, t
 
 Bede must know the user's current goals (professional certifications, hobbies like camping/piano/reading, fitness targets, career direction) and track progress toward them. It must notice when effort is drifting — too much mindless device time, skipped practice sessions, stalled projects — and call it out.
 
-Accountability means measuring reality against intention. Bede must know what the user said he would do (goals, weekly schedule) and what he actually did (screen time, media consumption, activity, location, calendar, task completion, vault edits). The gap between those is what matters.
+Accountability means measuring reality against intention. Bede must know what the user said they would do (goals, weekly schedule) and what they actually did (screen time, media consumption, activity, location, calendar, task completion, vault edits). The gap between those is what matters.
 
 This is closely linked to R1 — poor mental health often causes goal drift, and goal drift often worsens mental health. Bede must understand this connection and not treat them as independent.
 
@@ -53,11 +53,11 @@ This is closely linked to R1 — poor mental health often causes goal drift, and
 
 **I want to stay current in my professional and personal interests without having to go looking.**
 
-Bede must curate and deliver relevant content from the user's areas of interest — professional (software engineering, AI, cloud) and personal (music, camping, whatever The user defines). The user should not have to seek out this information himself; Bede should bring it to him in a digestible format.
+Bede must curate and deliver relevant content from the user's areas of interest — professional (software engineering, AI, cloud) and personal (music, camping, whatever The user defines). The user should not have to seek out this information; Bede should bring it to them in a digestible format.
 
 The sources, topics, and delivery cadence must be configurable by the user. Bede must be able to distinguish signal from noise — a curated summary is valuable, a firehose is not.
 
-**Success looks like:** The user learns about things that matter to him without opening a browser to go looking.
+**Success looks like:** The user learns about things that matter to them without opening a browser to go looking.
 
 **Measurable indicator:** The user receives at least one curated content delivery per configured topic per week.
 
@@ -73,7 +73,7 @@ If the user does not respond to the interactive prompt, Bede retries up to three
 
 **Success looks like:** The user starts each day and week knowing exactly what's ahead, with no unprocessed email creating background anxiety.
 
-**Measurable indicator:** The user receives a day briefing before his day starts on 90%+ of weekdays.
+**Measurable indicator:** The user receives a day briefing before their day starts on 90%+ of weekdays.
 
 ### R5. Personal knowledge base
 
@@ -83,7 +83,7 @@ Bede must integrate with the user's personal knowledge base (currently an Obsidi
 
 "Grow naturally" means low friction — capturing a thought should take seconds, not minutes of formatting and filing. Bede should suggest where to file things and how to organise them, but the user makes the final decision. Bede does not file autonomously.
 
-"Easy to search" means the user can ask Bede a question and get an answer that draws on his own notes, not just the AI's training data. The knowledge base must be the first place Bede looks for personal context.
+"Easy to search" means the user can ask Bede a question and get an answer that draws on their own notes, not just the model's training data. The knowledge base must be the first place Bede looks for personal context.
 
 The knowledge base must be stored as files the user owns and controls (Markdown preferred). It must be accessible from multiple devices (Mac, iPhone) and must not depend on any single vendor's sync service for its integrity.
 
@@ -101,7 +101,7 @@ Monitoring must run on a configurable schedule. Reports should only surface when
 
 Bede must be able to browse the web to check prices and availability, since many retailers don't offer APIs.
 
-**Success looks like:** The user gets timely alerts about deals he cares about without manually checking websites.
+**Success looks like:** The user gets timely alerts about deals they care about without manually checking websites.
 
 **Measurable indicator:** Price alerts are delivered within 24 hours of a price change on a monitored item.
 
@@ -115,7 +115,7 @@ Multi-turn conversations must be supported — Bede must remember what was discu
 
 This must not be limited to any specific domain. If the user asks about cooking, travel planning, or how to fix a shelf, Bede should help.
 
-**Success looks like:** The user uses Bede instead of a generic chat assistant because the answers are better — they account for his schedule, his health, his goals, and his history.
+**Success looks like:** The user uses Bede instead of a generic chat assistant because the answers are better — they account for their schedule, their health, their goals, and their history.
 
 **Measurable indicator:** Bede incorporates personal context (calendar, health, goals, or vault) in responses where relevant, without the user having to ask for it.
 
@@ -125,11 +125,11 @@ This must not be limited to any specific domain. If the user asks about cooking,
 
 Bede must support voice input and voice output as a secondary interaction mode. The primary use case is hands-free situations: driving, walking, cooking. The user speaks a message, Bede responds with audio. Walkie-talkie style (speak, wait, receive response) is acceptable — real-time phone-call-style conversation is not required.
 
-Voice must support the same capabilities as text — it's an alternative input/output mode, not a separate feature set. If the user can ask it in text, he can ask it by voice.
+Voice must support the same capabilities as text — it's an alternative input/output mode, not a separate feature set. If the user can ask it in text, they can ask it by voice.
 
 Creating tasks, capturing thoughts, and asking quick questions are the primary voice use cases.
 
-**Success looks like:** The user can interact with Bede while driving or doing chores, without reaching for his phone to type.
+**Success looks like:** The user can interact with Bede while driving or doing chores, without reaching for their phone to type.
 
 ### R9. Memory and continuity
 
@@ -145,7 +145,7 @@ What Bede remembers must be transparent — The user should be able to see and e
 
 When Bede gets something wrong based on its memory, The user must be able to correct it, and the correction must stick. Bede must not repeat a corrected mistake.
 
-**Success looks like:** Bede feels like it knows the user — not because it's guessing, but because it genuinely remembers past conversations, corrections, and context. The user never has to re-explain something he's already told Bede.
+**Success looks like:** Bede feels like it knows the user — not because it's guessing, but because it genuinely remembers past conversations, corrections, and context. The user never has to re-explain something they've already told Bede.
 
 ---
 
@@ -155,11 +155,11 @@ These are non-negotiable boundaries the system must operate within.
 
 ### C1. Own hardware
 
-The system must run on hardware the user owns and controls, in his home. No cloud-hosted compute for the assistant itself. The server runs Linux or Windows. Cloud services may be used for specific functions (e.g., AI inference, DNS, email APIs) but the assistant's core logic, data, and state must reside on the user's hardware.
+The system must run on hardware the user owns and controls, in their home. No cloud-hosted compute for the assistant itself. The server runs Linux or Windows. Cloud services may be used for specific functions (e.g., AI inference, DNS, email APIs) but the assistant's core logic, data, and state must reside on the user's hardware.
 
 ### C2. Data sovereignty
 
-All personal data — health, location, screen time, calendar, email content, conversation history, knowledge base — must be stored on the user's own infrastructure. Data may transit third-party services for processing (e.g., sending a prompt to Claude for inference) but must not be stored by third parties beyond what is necessary for the service to function. The user must be able to delete all his data by deleting files on his own server.
+All personal data — health, location, screen time, calendar, email content, conversation history, knowledge base — must be stored on the user's own infrastructure. Data may transit third-party services for processing (e.g., sending a prompt to Claude for inference) but must not be stored by third parties beyond what is necessary for the service to function. The user must be able to delete all their data by deleting files on their own server.
 
 ### C3. Claude subscription
 

--- a/docs/superpowers/specs/2026-04-29-bede-requirements.md
+++ b/docs/superpowers/specs/2026-04-29-bede-requirements.md
@@ -31,9 +31,11 @@ Coaching means ongoing, not reactive. Bede should check in regularly, notice whe
 
 The coaching relationship must be configurable — the user controls the tone, the boundaries, and what topics are in scope. If the user says "back off on this topic," Bede must respect that immediately and durably.
 
+Bede is not a substitute for professional mental health support. If it detects signals of serious distress or crisis, it must recommend professional resources and not attempt to manage the situation itself.
+
 **Success looks like:** The user feels like someone is genuinely watching out for them and will say something honest when patterns emerge — not just echoing data back.
 
-**Measurable indicator:** Bede surfaces a concern about a negative pattern within 48 hours of the pattern emerging (e.g., 3 consecutive poor sleeps flagged by day 4). What constitutes a negative pattern varies by signal and must be configurable.
+**Measurable indicator:** Bede surfaces a concern about a negative pattern within 48 hours of the pattern becoming detectable (e.g., 3 consecutive poor sleeps flagged by day 4). What constitutes a negative pattern varies by signal and must be configurable.
 
 ### R2. Goal accountability
 
@@ -65,7 +67,9 @@ The sources, topics, and delivery cadence must be configurable by the user. Bede
 
 **I want to know what my day and week look like before they start — including emails triaged into tasks, events, or dismissed.**
 
-Bede must prepare a view of the upcoming day (and week, at appropriate cadence) that includes: calendar events, weather, air quality, relevant reminders and tasks, and any actions extracted from email. Email triage follows a strict pattern: each email becomes a task, becomes an event, or is dismissed as requiring no action. Bede proposes the classification; the user confirms or corrects.
+Bede must prepare a view of the upcoming day (and week, at appropriate cadence) that includes: calendar events, weather, air quality, relevant reminders and tasks, and any actions extracted from email. Email triage follows a strict pattern: each email becomes a task, becomes an event, or is dismissed as requiring no action. Bede should pre-filter obvious noise (automated notifications, marketing) and only present emails that plausibly require action or attention. Bede proposes the classification; the user confirms or corrects.
+
+The work calendar is not accessible (see Section 4) — the day job is a black box. Day planning covers personal calendars, professional development, and personal projects. Bede is not expected to plan around work meetings.
 
 This must be delivered proactively before the day/week starts, not on demand. The delivery must be interactive — Bede asks questions, the user provides input, then Bede delivers the final view. The user must be able to correct, reprioritise, or add items during the interaction.
 
@@ -125,7 +129,7 @@ Creating tasks, capturing thoughts, and asking quick questions are the primary v
 
 Bede must maintain context beyond a single conversation. This includes:
 
-- **Within a conversation:** multi-turn context so Bede doesn't forget what was just discussed.
+- **Within a conversation:** see R6.
 - **Across conversations:** Bede must remember significant facts, preferences, corrections, and commitments the user has made, even days or weeks later. If the user says "I'm training for a half marathon" in March, Bede should still know that in June.
 - **Pattern recognition over time:** R1 (coaching) and R2 (accountability) require Bede to detect trends across days and weeks — sleep patterns, exercise consistency, goal progress. This requires access to historical data, not just today's snapshot.
 
@@ -169,7 +173,7 @@ The system must use a Claude subscription (flat monthly cost), not per-token API
 
 ### C4. Minimal-setup interface
 
-The interface must be usable from an iPhone using only apps available from the App Store, with no custom app development or App Store deployment required. Server-side setup should be achievable in under an hour for someone comfortable with Docker, SSH, and Linux system administration.
+The interface must be usable from an iPhone using only widely available apps from the App Store, with no custom app development or App Store deployment required. Server-side setup should be achievable in under an hour for someone comfortable with Docker, SSH, and Linux system administration.
 
 The interface must support push delivery — Bede must be able to reach the user without the user opening the app first.
 
@@ -181,7 +185,10 @@ The knowledge base must be stored as Markdown files that the user owns. It must 
 
 ### C6. Maintenance budget
 
-The system must run unattended on weeknights without manual intervention. Maintenance and feature work happens on weekends (target: a couple of hours). The system must not require more than one manual intervention per week on average. When things break, failures must be visible — not silent.
+- **Availability:** The system must run unattended on weeknights without manual intervention.
+- **Development effort:** Maintenance and feature work happens on weekends (target: a couple of hours).
+- **Operational reliability:** The system must not require more than one manual intervention per week on average.
+- **Failure visibility:** When things break, failures must be visible — not silent.
 
 ### C7. Scheduled interaction style
 
@@ -254,13 +261,13 @@ Not all data needs to arrive in real-time. Approximate expectations:
 
 | Category | Freshness | Rationale |
 |----------|-----------|-----------|
-| Calendar, email, tasks | Near real-time (minutes) | Day planning needs current state |
+| Calendar, email, tasks | Within 15 minutes | Day planning needs current state |
 | Location | Near real-time when queried | "Where am I?" must be accurate now |
 | Weather and air quality | Hourly | Forecasts don't change faster |
 | Health (sleep, activity, HR) | Daily | Collected overnight or end-of-day |
 | Screen time, browsing history | Daily | Batch collection is sufficient |
 | Media consumption | Daily | Batch collection is sufficient |
-| Knowledge base | Minutes | Captures should appear quickly |
+| Knowledge base | Under 1 minute | Captures should appear quickly |
 | Conversation history | Immediate | Must be available within the same session |
 | Goals and schedule | On change | Only updates when the user edits them |
 
@@ -288,7 +295,7 @@ These apply across all functional requirements.
 ### Configurability
 - The user must be able to change Bede's personality, tone, and boundaries.
 - Scheduled tasks, monitored items, interest topics, and goal definitions must all be editable by the user without code changes.
-- The user must be able to make routine configuration changes (tone, schedules, monitored items, corrections) through conversation with Bede, not only by editing files.
+- The user must be able to make routine configuration changes (tone, schedules, monitored items, corrections) through conversation with Bede, not only by editing files. When the user requests a change, Bede updates the underlying config files on their behalf — conversation is the input method, files are the storage.
 - Configuration should be stored as human-readable files, not in databases or admin UIs.
 
 ### Auditability


### PR DESCRIPTION
## Summary
- **Bede PRD** (`2026-04-28-bede-prd.md`): Documents current Bede architecture, components, data stores, features, security, and reliability. Includes analysis of patterns from Hermes and OpenClaw projects.
- **Bede Requirements** (`2026-04-29-bede-requirements.md`): Implementation-agnostic requirements document defining what Bede must do and the constraints it must operate within. 9 functional requirements (R1-R9), 7 constraints (C1-C7), data inputs with freshness expectations, and cross-cutting requirements. Refined through three independent product owner review cycles.

The requirements document is the primary deliverable — it will be the reference for a subsequent design document that explores architecture options from scratch.

## Test plan
- [ ] Review both documents for accuracy and completeness
- [ ] Confirm requirements document stands alone without external context
- [ ] Confirm no implementation details leaked into requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)