### PR TITLE
feat: use GHCR image for bede-data

### DIFF
--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -47,7 +47,7 @@ services:
       - "traefik.http.services.workspace-mcp.loadbalancer.server.port=8003"
 
   bede-data:
-    image: bede-data:latest
+    image: ghcr.io/josephradford/bede-data:latest
     container_name: bede-data
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
- Switches `bede-data` service from locally built `bede-data:latest` to prebuilt `ghcr.io/josephradford/bede-data:latest`
- Aligns with the existing bede service pattern (prebuilt GHCR images)

## Dependencies
- Requires [josephradford/bede CI PR](https://github.com/josephradford/bede/pull/) to merge first so the GHCR image exists

## Test plan
- [ ] `make validate` passes
- [ ] After bede CI PR merges and image is published, `make bede-pull && make bede-restart` works on server

🤖 Generated with [Claude Code](https://claude.com/claude-code)