### PR TITLE
feat: add bede-data-mcp to Docker Compose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Add peers: `sudo ./scripts/wireguard/wireguard-add-peer.sh <name>`
 - `docker-compose.network.yml` — Network & security (Traefik, Fail2ban)
 - `docker-compose.monitoring.yml` — Monitoring (Prometheus, Grafana, Alertmanager, exporters)
 - `docker-compose.dashboard.yml` — Dashboard (Homepage, Homepage API)
-- `docker-compose.ai.yml` — AI services (bede + bede-data — prebuilt GHCR images from josephradford/bede)
+- `docker-compose.ai.yml` — AI services (bede + bede-data + bede-data-mcp — prebuilt GHCR images from josephradford/bede)
 
 The Makefile combines all five files by default.
 

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -73,6 +73,24 @@ services:
       - "traefik.http.routers.data-ingest.service=data-ingest"
       - "traefik.http.services.data-ingest.loadbalancer.server.port=8001"
 
+  bede-data-mcp:
+    image: ghcr.io/josephradford/bede-data-mcp:latest
+    container_name: bede-data-mcp
+    restart: unless-stopped
+    environment:
+      - BEDE_DATA_URL=http://bede-data:8001
+      - DATA_MCP_PORT=8002
+    networks:
+      - homeserver
+    depends_on:
+      bede-data:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('localhost', 8002), timeout=5); s.close()"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
 networks:
   homeserver:
     external: true


### PR DESCRIPTION
## Summary
- Adds `bede-data-mcp` service to `docker-compose.ai.yml` — depends on bede-data healthy, TCP socket healthcheck on port 8002
- Updates `CLAUDE.md` architecture section to include bede-data-mcp

## Dependencies
- Requires [bede PR](https://github.com/josephradford/bede/pull/new/feat/bede-data-mcp) to be merged and GHCR image published first
- GHCR package `bede-data-mcp` must be set to public visibility before the server can pull it

## Test plan
- [x] `make validate` passes
- [ ] After bede image is published: `make bede-pull && make bede-restart` on server
- [ ] Verify bede-data-mcp container starts healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)