### PR TITLE
Fix homepage container names and add missing services

### DIFF
--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -242,9 +242,40 @@
 
   # AI Services - Bede assistant and workspace integrations
   - AI Services:
-      - Bede:
+      - Bede Core:
           icon: mdi-robot
-          description: Personal AI assistant with data & workspace services
-          container: bede
+          description: Personal assistant
+          container: bede-core
+          server: my-docker
+          showStats: true
+
+      - Bede Data:
+          icon: mdi-database
+          description: Data ingest & query API
+          container: bede-data
+          server: my-docker
+          showStats: true
+
+      - Bede Data MCP:
+          icon: mdi-connection
+          description: MCP server for Bede data access
+          container: bede-data-mcp
+          server: my-docker
+          showStats: true
+
+  # Location Services - Location tracking
+  - Location:
+      - OwnTracks:
+          icon: mdi-map-marker
+          href: https://owntracks.{{HOMEPAGE_VAR_DOMAIN}}
+          description: Location tracking recorder
+          container: owntracks-recorder
+          server: my-docker
+          showStats: true
+
+      - Mosquitto:
+          icon: mdi-access-point
+          description: MQTT broker (internal)
+          container: mosquitto
           server: my-docker
           showStats: true

--- a/config/homepage/settings-template.yaml
+++ b/config/homepage/settings-template.yaml
@@ -35,8 +35,13 @@ layout:
     Network & Security:
       style: row
       columns: 3
-  
-  
+    AI Services:
+      style: row
+      columns: 3
+    Location:
+      style: row
+      columns: 2
+
 
 # UI preferences
 statusStyle: "dot"


### PR DESCRIPTION
## Summary
- Update `bede` container reference to `bede-core` (old service is disabled)
- Add separate entries for `bede-data` and `bede-data-mcp` services
- Add new Location section with OwnTracks recorder and Mosquitto broker
- Fix settings layout to include AI Services and Location group definitions

## Test plan
- [ ] Merge and deploy to server
- [ ] Re-run `configure-homepage.sh` on server to copy updated templates
- [ ] Verify all container status dots are green on homepage
- [ ] Verify new Location section appears with OwnTracks and Mosquitto

🤖 Generated with [Claude Code](https://claude.com/claude-code)