### PR TITLE
fix: bede-data OwnTracks config and bede-pull improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ help:
 	@echo "  make location-status    - Show OwnTracks container status"
 	@echo ""
 	@echo "Bede AI Assistant (Individual Service Management):"
-	@echo "  make bede-pull          - Pull latest Bede image from GHCR"
+	@echo "  make bede-pull          - Pull latest Bede images from GHCR"
 	@echo "  make bede-start         - Start Bede AI services only"
 	@echo "  make bede-stop          - Stop Bede AI services only"
 	@echo "  make bede-restart       - Restart Bede AI services only"
@@ -357,9 +357,12 @@ logs-owntracks:
 COMPOSE_AI := docker compose -f docker-compose.ai.yml
 
 bede-pull: env-check
-	@echo "Pulling Bede image..."
+	@echo "Pulling Bede images..."
 	@docker pull ghcr.io/josephradford/bede:latest
-	@echo "✓ Bede image pulled"
+	@docker pull ghcr.io/josephradford/bede-data:latest
+	@docker pull ghcr.io/josephradford/bede-data-mcp:latest
+	@docker pull ghcr.io/josephradford/bede-core:latest
+	@echo "✓ Bede images pulled"
 
 bede-start: env-check
 	@echo "Starting Bede..."

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -54,10 +54,14 @@ services:
       - SQLITE_DB_PATH=/data/sqlite/bede.db
       - INGEST_WRITE_TOKEN=${INGEST_WRITE_TOKEN}
       - TIMEZONE=${TIMEZONE:-Australia/Sydney}
+      - OWNTRACKS_URL=http://owntracks-recorder:8083
+      - OWNTRACKS_USER=${OWNTRACKS_USER}
+      - OWNTRACKS_DEVICE=${OWNTRACKS_DEVICE}
     volumes:
       - ./data/bede/sqlite:/data/sqlite
     networks:
       - homeserver
+      - location
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
       interval: 30s

--- a/docs/superpowers/plans/2026-05-01-bede-core-prototype-parity.md
+++ b/docs/superpowers/plans/2026-05-01-bede-core-prototype-parity.md
@@ -86,7 +86,7 @@ main.py
 
 When a scheduled task is `interactive: true`, the session manager must override the model for subsequent user messages and track idle/max-age timeouts. The daily session ID is already shared — interactive mode just changes which model is used and marks the session as interactive.
 
-- [ ] **Step 1: Write the interactive session tests**
+- [x] **Step 1: Write the interactive session tests**
 
 Add to `bede-core/tests/test_session_manager.py`:
 
@@ -196,12 +196,12 @@ class TestInteractiveSession:
         assert sm.is_interactive is False
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_session_manager.py::TestInteractiveSession -v`
 Expected: FAIL — `register_interactive` does not exist.
 
-- [ ] **Step 3: Add interactive state to SessionManager**
+- [x] **Step 3: Add interactive state to SessionManager**
 
 Modify `bede-core/src/bede_core/session_manager.py`:
 
@@ -330,7 +330,7 @@ class SessionManager:
     # ... existing send_task, clear_daily_session, append_scratchpad_entry unchanged ...
 ```
 
-- [ ] **Step 4: Update SessionManager constructor in main.py**
+- [x] **Step 4: Update SessionManager constructor in main.py**
 
 Modify the SessionManager instantiation in `bede-core/src/bede_core/main.py`:
 
@@ -347,14 +347,14 @@ Modify the SessionManager instantiation in `bede-core/src/bede_core/main.py`:
     )
 ```
 
-- [ ] **Step 5: Update the `sm` fixture in tests to match new signature**
+- [x] **Step 5: Update the `sm` fixture in tests to match new signature**
 
 The existing `sm` fixture in `test_session_manager.py` must accept the new kwargs without breaking. The defaults handle this — no fixture change needed since the new params have defaults. Verify:
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_session_manager.py -v`
 Expected: All tests pass (existing + new interactive tests).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -372,7 +372,7 @@ git commit -m "feat(bede-core): interactive session tracking with model override
 
 After a task with `interactive: true` runs successfully, the TaskRunner registers the interactive session in the SessionManager so subsequent user messages use the task's model.
 
-- [ ] **Step 1: Write the interactive handoff test**
+- [x] **Step 1: Write the interactive handoff test**
 
 Add to `bede-core/tests/test_scheduler.py`:
 
@@ -436,12 +436,12 @@ class TestInteractiveHandoff:
         session_manager.register_interactive.assert_not_called()
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_scheduler.py::TestInteractiveHandoff -v`
 Expected: FAIL — `register_interactive` never called.
 
-- [ ] **Step 3: Add interactive handoff to `_run_task_inner`**
+- [x] **Step 3: Add interactive handoff to `_run_task_inner`**
 
 Modify `bede-core/src/bede_core/scheduler.py`, in `_run_task_inner`, after the successful output handling (after the quiet hours check block):
 
@@ -498,12 +498,12 @@ Modify `bede-core/src/bede_core/scheduler.py`, in `_run_task_inner`, after the s
             self._session.register_interactive(model)
 ```
 
-- [ ] **Step 4: Run all scheduler tests**
+- [x] **Step 4: Run all scheduler tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_scheduler.py -v`
 Expected: All pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -525,7 +525,7 @@ git commit -m "feat(bede-core): interactive task handoff from scheduler to sessi
 
 During interactive sessions, the user's messages are corrections/feedback to the scheduled task output (e.g., Evening Reflection). These corrections are appended to `Bede/reflection-memory.md` in the vault and committed+pushed so they're available on the next run.
 
-- [ ] **Step 1: Write the reflection module tests**
+- [x] **Step 1: Write the reflection module tests**
 
 Create `bede-core/tests/test_reflection.py`:
 
@@ -575,12 +575,12 @@ class TestReflection:
         assert "2026-" in content
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_reflection.py -v`
 Expected: FAIL — `bede_core.reflection` does not exist.
 
-- [ ] **Step 3: Implement the reflection module**
+- [x] **Step 3: Implement the reflection module**
 
 Create `bede-core/src/bede_core/reflection.py`:
 
@@ -637,12 +637,12 @@ def append_correction(text: str, vault_path: str, timezone: str):
     _git_commit_push(vault_path, full_path)
 ```
 
-- [ ] **Step 4: Run reflection tests**
+- [x] **Step 4: Run reflection tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_reflection.py -v`
 Expected: All pass.
 
-- [ ] **Step 5: Write bot interactive correction test**
+- [x] **Step 5: Write bot interactive correction test**
 
 Add to `bede-core/tests/test_bot.py`:
 
@@ -702,7 +702,7 @@ class TestInteractiveCorrections:
         assert len(correction_calls) == 0
 ```
 
-- [ ] **Step 6: Add correction call to bot message handler**
+- [x] **Step 6: Add correction call to bot message handler**
 
 Modify `bede-core/src/bede_core/bot.py`. Update `create_message_handler` to accept an `append_correction_fn` parameter, and call it during interactive sessions:
 
@@ -767,7 +767,7 @@ def create_message_handler(
     return handle_message
 ```
 
-- [ ] **Step 7: Wire correction function in main.py**
+- [x] **Step 7: Wire correction function in main.py**
 
 Modify the message handler creation in `bede-core/src/bede_core/main.py`:
 
@@ -799,16 +799,16 @@ Then update the `create_message_handler` call:
     )
 ```
 
-- [ ] **Step 8: Add `vault_repo` to config (needed by entrypoint, already exists as env var)**
+- [x] **Step 8: Add `vault_repo` to config (needed by entrypoint, already exists as env var)**
 
 Verify `VAULT_REPO` is already available in `docker-compose.ai.yml` for bede-core. It is — line 109 has `VAULT_REPO=${VAULT_REPO}`. No config.py change needed since `reflection.py` takes `vault_path` directly.
 
-- [ ] **Step 9: Run all tests**
+- [x] **Step 9: Run all tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/ -v`
 Expected: All pass.
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -829,7 +829,7 @@ git commit -m "feat(bede-core): reflection memory — append corrections during 
 
 When the user sends `/reset`, all running scheduled tasks should be cancelled and their subprocesses killed. The user should see which tasks were cancelled.
 
-- [ ] **Step 1: Write the cancel tests**
+- [x] **Step 1: Write the cancel tests**
 
 Add to `bede-core/tests/test_scheduler.py`:
 
@@ -849,12 +849,12 @@ class TestCancelTasks:
         assert cancelled == []
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_scheduler.py::TestCancelTasks -v`
 Expected: FAIL — `cancel_all` does not exist.
 
-- [ ] **Step 3: Add `cancel_all` to TaskRunner**
+- [x] **Step 3: Add `cancel_all` to TaskRunner**
 
 Add to `bede-core/src/bede_core/scheduler.py`, in the `TaskRunner` class:
 
@@ -865,7 +865,7 @@ Add to `bede-core/src/bede_core/scheduler.py`, in the `TaskRunner` class:
         return cancelled
 ```
 
-- [ ] **Step 4: Write bot reset cancel test**
+- [x] **Step 4: Write bot reset cancel test**
 
 Add to `bede-core/tests/test_bot.py`:
 
@@ -909,7 +909,7 @@ class TestResetCancellation:
         assert "cleared" in reply_text.lower()
 ```
 
-- [ ] **Step 5: Update `create_reset_handler` to accept runner**
+- [x] **Step 5: Update `create_reset_handler` to accept runner**
 
 Modify `bede-core/src/bede_core/bot.py`:
 
@@ -930,7 +930,7 @@ def create_reset_handler(session_manager: SessionManager, allowed_user_id: int, 
     return handle_reset
 ```
 
-- [ ] **Step 6: Pass runner to reset handler in main.py**
+- [x] **Step 6: Pass runner to reset handler in main.py**
 
 Modify `bede-core/src/bede_core/main.py`:
 
@@ -942,12 +942,12 @@ Modify `bede-core/src/bede_core/main.py`:
     )
 ```
 
-- [ ] **Step 7: Run all tests**
+- [x] **Step 7: Run all tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/ -v`
 Expected: All pass.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -967,7 +967,7 @@ git commit -m "feat(bede-core): cancel running tasks and clear interactive sessi
 
 The prototype shows a typing indicator in Telegram while scheduled tasks are running. The bot reply handler should also set `disable_web_page_preview=True`.
 
-- [ ] **Step 1: Write typing indicator test**
+- [x] **Step 1: Write typing indicator test**
 
 Add to `bede-core/tests/test_scheduler.py`:
 
@@ -1002,12 +1002,12 @@ class TestTypingIndicator:
         typing_fn.assert_called()
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_scheduler.py::TestTypingIndicator -v`
 Expected: FAIL — `typing_fn` not accepted.
 
-- [ ] **Step 3: Add typing support to TaskRunner**
+- [x] **Step 3: Add typing support to TaskRunner**
 
 Modify `bede-core/src/bede_core/scheduler.py`. Add `typing_fn` to `__init__` and call it in `run_task`:
 
@@ -1068,7 +1068,7 @@ Modify `run_task` to start typing before task execution:
 
 Add `import asyncio` at the top of the file if not already present.
 
-- [ ] **Step 4: Create typing function in main.py**
+- [x] **Step 4: Create typing function in main.py**
 
 Add to `bede-core/src/bede_core/main.py`, before the `runner` creation:
 
@@ -1099,7 +1099,7 @@ Add `import asyncio, time` at the top. Pass `typing_fn=keep_typing` to the `Task
     )
 ```
 
-- [ ] **Step 5: Add `disable_web_page_preview` to bot reply handler**
+- [x] **Step 5: Add `disable_web_page_preview` to bot reply handler**
 
 Modify `bede-core/src/bede_core/bot.py`, in `_send_response`:
 
@@ -1114,12 +1114,12 @@ async def _send_response(message, text: str):
             await message.reply_text(c, disable_web_page_preview=True)
 ```
 
-- [ ] **Step 6: Run all tests**
+- [x] **Step 6: Run all tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/ -v`
 Expected: All pass.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -1139,7 +1139,7 @@ git commit -m "feat(bede-core): typing indicator during scheduled tasks, disable
 
 Add a `task_config` TEXT column (JSON, nullable) to the `schedules` table. This holds multi-step task definitions. When null, the task is a single-step task using the `prompt` field.
 
-- [ ] **Step 1: Write the API test for task_config**
+- [x] **Step 1: Write the API test for task_config**
 
 Add to `bede-data/tests/test_api_config.py`:
 
@@ -1196,12 +1196,12 @@ class TestScheduleTaskConfig:
         assert found[0]["task_config"] == config
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `cd /Users/joeradford/dev/bede/bede-data && uv run pytest tests/test_api_config.py::TestScheduleTaskConfig -v`
 Expected: FAIL — `task_config` not accepted or not returned.
 
-- [ ] **Step 3: Update schema**
+- [x] **Step 3: Update schema**
 
 Modify `bede-data/src/bede_data/db/schema.py`:
 
@@ -1225,7 +1225,7 @@ CREATE TABLE IF NOT EXISTS schedules (
 );
 ```
 
-- [ ] **Step 4: Add migration in connection.py**
+- [x] **Step 4: Add migration in connection.py**
 
 Modify `bede-data/src/bede_data/db/connection.py`, in `init_db`, add migration before `conn.executescript(SCHEMA_SQL)`:
 
@@ -1240,7 +1240,7 @@ Modify `bede-data/src/bede_data/db/connection.py`, in `init_db`, add migration b
 
 This goes after the existing `if existing is not None and existing < 3:` block and before `conn.executescript(SCHEMA_SQL)`.
 
-- [ ] **Step 5: Update API models and endpoints**
+- [x] **Step 5: Update API models and endpoints**
 
 Modify `bede-data/src/bede_data/api/config_api.py`:
 
@@ -1312,12 +1312,12 @@ Add `task_config` to the update logic in `update_schedule`:
             updates[field] = val
 ```
 
-- [ ] **Step 6: Run all bede-data tests**
+- [x] **Step 6: Run all bede-data tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-data && uv run pytest tests/ -v`
 Expected: All pass.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -1335,7 +1335,7 @@ git commit -m "feat(bede-data): add task_config column to schedules for multi-st
 
 When a task has `task_config` with `steps`, TaskRunner runs each step as a separate Claude invocation. Steps can run sequentially (default) or in parallel (`parallel: true`). Silent steps execute but don't send output to Telegram. The main `prompt` field serves as preamble context for all steps.
 
-- [ ] **Step 1: Write multi-step tests**
+- [x] **Step 1: Write multi-step tests**
 
 Add to `bede-core/tests/test_scheduler.py`:
 
@@ -1492,12 +1492,12 @@ class TestMultiStepTasks:
         session_manager.send_task.assert_called_once()
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_scheduler.py::TestMultiStepTasks -v`
 Expected: FAIL — multi-step logic not implemented.
 
-- [ ] **Step 3: Implement multi-step execution**
+- [x] **Step 3: Implement multi-step execution**
 
 Modify `bede-core/src/bede_core/scheduler.py`. Add a `json` import. Modify `_run_task_inner` to check for `task_config`:
 
@@ -1649,17 +1649,17 @@ import json
         await self._send(f"✅ *{name}* complete.")
 ```
 
-- [ ] **Step 4: Run all tests**
+- [x] **Step 4: Run all tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/ -v`
 Expected: All pass.
 
-- [ ] **Step 5: Lint and format**
+- [x] **Step 5: Lint and format**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run ruff check src/ tests/ --fix && uv run ruff format src/ tests/`
 Expected: No errors.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede

--- a/docs/superpowers/plans/2026-05-01-bede-core.md
+++ b/docs/superpowers/plans/2026-05-01-bede-core.md
@@ -103,7 +103,7 @@ main.py
 - Create: `bede-core/tests/conftest.py`
 - Create: `bede-core/tests/test_config.py`
 
-- [ ] **Step 1: Write the config test**
+- [x] **Step 1: Write the config test**
 
 ```python
 # tests/test_config.py
@@ -147,12 +147,12 @@ def test_settings_from_env(monkeypatch):
     assert s.bede_data_url == "http://localhost:8001"
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_config.py -v`
 Expected: FAIL — module `bede_core.config` does not exist yet.
 
-- [ ] **Step 3: Create pyproject.toml**
+- [x] **Step 3: Create pyproject.toml**
 
 ```toml
 # bede-core/pyproject.toml
@@ -191,7 +191,7 @@ pythonpath = ["src"]
 asyncio_mode = "auto"
 ```
 
-- [ ] **Step 4: Create __init__.py**
+- [x] **Step 4: Create __init__.py**
 
 ```python
 # bede-core/src/bede_core/__init__.py
@@ -199,7 +199,7 @@ asyncio_mode = "auto"
 
 (Empty file.)
 
-- [ ] **Step 5: Create config.py**
+- [x] **Step 5: Create config.py**
 
 ```python
 # bede-core/src/bede_core/config.py
@@ -224,7 +224,7 @@ class Settings(BaseSettings):
     model_config = {"env_prefix": "", "case_sensitive": False}
 ```
 
-- [ ] **Step 6: Create conftest.py**
+- [x] **Step 6: Create conftest.py**
 
 ```python
 # bede-core/tests/conftest.py
@@ -232,12 +232,12 @@ class Settings(BaseSettings):
 
 (Empty for now — fixtures added per-task as needed.)
 
-- [ ] **Step 7: Run tests**
+- [x] **Step 7: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv sync --extra dev && uv run pytest tests/test_config.py -v`
 Expected: PASS — both tests pass.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -255,7 +255,7 @@ git commit -m "feat(bede-core): project scaffold and configuration"
 
 This is a thin httpx wrapper, modelled on `bede-data-mcp/src/bede_data_mcp/client.py` but without `fastmcp` dependency. It exposes `get()`, `post()`, `put()`, `delete()` helpers that hit bede-data's HTTP API.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```python
 # bede-core/tests/test_data_client.py
@@ -315,16 +315,16 @@ class TestDataClient:
         assert "404" in result["error"]
 ```
 
-- [ ] **Step 2: Add pytest-httpx dev dependency**
+- [x] **Step 2: Add pytest-httpx dev dependency**
 
 Add `"pytest-httpx>=0.35.0"` to `[project.optional-dependencies] dev` in `bede-core/pyproject.toml`.
 
-- [ ] **Step 3: Run test to verify it fails**
+- [x] **Step 3: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv sync --extra dev && uv run pytest tests/test_data_client.py -v`
 Expected: FAIL — `bede_core.data_client` does not exist.
 
-- [ ] **Step 4: Write the data client**
+- [x] **Step 4: Write the data client**
 
 ```python
 # bede-core/src/bede_core/data_client.py
@@ -362,12 +362,12 @@ class DataClient:
         return await self._request("DELETE", path)
 ```
 
-- [ ] **Step 5: Run tests**
+- [x] **Step 5: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_data_client.py -v`
 Expected: PASS — all 5 tests pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -385,7 +385,7 @@ git commit -m "feat(bede-core): data client for bede-data HTTP API"
 
 Port the existing `utils.py:md_to_html()` and `bot.py:_chunk_text()` — these are pure functions, easy to test in isolation.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```python
 # bede-core/tests/test_telegram_format.py
@@ -454,12 +454,12 @@ class TestChunkText:
         assert "".join(chunks) == text
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_telegram_format.py -v`
 Expected: FAIL — module does not exist.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 ```python
 # bede-core/src/bede_core/telegram_format.py
@@ -502,12 +502,12 @@ def chunk_text(text: str, max_len: int = 4096) -> list[str]:
     return chunks
 ```
 
-- [ ] **Step 4: Run tests**
+- [x] **Step 4: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_telegram_format.py -v`
 Expected: PASS — all tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -525,7 +525,7 @@ git commit -m "feat(bede-core): telegram markdown-to-html formatter and text chu
 
 Pure logic: is it currently quiet hours? Queue notification delivery for after quiet hours end.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```python
 # bede-core/tests/test_quiet_hours.py
@@ -568,12 +568,12 @@ def test_quiet_hours_disabled():
     assert is_quiet_hours(dt, start_hour=0, end_hour=0) is False
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_quiet_hours.py -v`
 Expected: FAIL — module does not exist.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 ```python
 # bede-core/src/bede_core/quiet_hours.py
@@ -594,12 +594,12 @@ def is_quiet_hours(now: datetime, start_hour: int, end_hour: int) -> bool:
     return start_hour <= hour < end_hour
 ```
 
-- [ ] **Step 4: Run tests**
+- [x] **Step 4: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_quiet_hours.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -617,7 +617,7 @@ git commit -m "feat(bede-core): quiet hours logic"
 
 Low-level subprocess wrapper. Builds the `claude -p` command, runs it with timeout and clean termination, parses the JSON output. This replaces `_build_cmd()`, `_run_claude()`, and `_parse_output()` from the prototype bot.py.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```python
 # bede-core/tests/test_claude_cli.py
@@ -753,12 +753,12 @@ class TestClaudeCli:
         assert captured_env.get("SAFE_VAR") == "ok"
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_claude_cli.py -v`
 Expected: FAIL — module does not exist.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 ```python
 # bede-core/src/bede_core/claude_cli.py
@@ -911,12 +911,12 @@ class ClaudeCli:
         return result
 ```
 
-- [ ] **Step 4: Run tests**
+- [x] **Step 4: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_claude_cli.py -v`
 Expected: PASS — all tests pass. (Some tests may need minor fixture adjustments — the env filtering test is testing intent, the exact assertion depends on implementation.)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -934,7 +934,7 @@ git commit -m "feat(bede-core): claude CLI subprocess runner with timeout and en
 
 Retrieves relevant memories from bede-data and formats them for injection into Claude's context. Handles memory budget (capped total characters).
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```python
 # bede-core/tests/test_memory_manager.py
@@ -998,12 +998,12 @@ class TestMemoryManager:
         assert result["id"] == 5
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_memory_manager.py -v`
 Expected: FAIL — module does not exist.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 ```python
 # bede-core/src/bede_core/memory_manager.py
@@ -1056,12 +1056,12 @@ class MemoryManager:
         return await self._client.post("/api/memories", body=body)
 ```
 
-- [ ] **Step 4: Run tests**
+- [x] **Step 4: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_memory_manager.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -1079,7 +1079,7 @@ git commit -m "feat(bede-core): memory manager for context injection and storage
 
 The critical abstraction. Manages daily session continuity: one Claude session per day, resumed via `--resume`. Handles scratchpad updates, fresh session fallback, memory injection, and vault pull.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```python
 # bede-core/tests/test_session_manager.py
@@ -1214,12 +1214,12 @@ class TestSessionManager:
         assert len(scratchpad_calls) == 0
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_session_manager.py -v`
 Expected: FAIL — module does not exist.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 ```python
 # bede-core/src/bede_core/session_manager.py
@@ -1384,12 +1384,12 @@ class SessionManager:
         await self._append_scratchpad(content)
 ```
 
-- [ ] **Step 4: Run tests**
+- [x] **Step 4: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_session_manager.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -1407,7 +1407,7 @@ git commit -m "feat(bede-core): session manager with daily session continuity"
 
 Reads task definitions from bede-data's config API (SQLite-backed schedules), registers APScheduler cron triggers, fires tasks through the Session Manager, logs executions to bede-data's task log API. Polls for config changes on a timer.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```python
 # bede-core/tests/test_scheduler.py
@@ -1533,12 +1533,12 @@ class TestTaskRunner:
         session_manager.send_task.assert_not_called()
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_scheduler.py -v`
 Expected: FAIL — module does not exist.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 ```python
 # bede-core/src/bede_core/scheduler.py
@@ -1741,12 +1741,12 @@ def setup_scheduler(
     return scheduler
 ```
 
-- [ ] **Step 4: Run tests**
+- [x] **Step 4: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_scheduler.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -1764,7 +1764,7 @@ git commit -m "feat(bede-core): scheduler with task loading, execution, and audi
 
 Telegram message handling, user auth, typing indicator, commands. This is the user-facing layer that delegates to the Session Manager.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```python
 # bede-core/tests/test_bot.py
@@ -1887,12 +1887,12 @@ class TestResetHandler:
         session_manager.clear_daily_session.assert_not_called()
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_bot.py -v`
 Expected: FAIL — module does not exist.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 ```python
 # bede-core/src/bede_core/bot.py
@@ -2033,12 +2033,12 @@ def create_task_trigger_handler(
     return handle_trigger
 ```
 
-- [ ] **Step 4: Run tests**
+- [x] **Step 4: Run tests**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run pytest tests/test_bot.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -2055,7 +2055,7 @@ git commit -m "feat(bede-core): telegram bot handlers with auth, typing, and err
 
 Wires everything together: creates settings, data client, claude CLI, memory manager, session manager, scheduler, and Telegram bot application. No tests needed for wiring — the integration test is "does it start up".
 
-- [ ] **Step 1: Write main.py**
+- [x] **Step 1: Write main.py**
 
 ```python
 # bede-core/src/bede_core/main.py
@@ -2213,12 +2213,12 @@ if __name__ == "__main__":
     main()
 ```
 
-- [ ] **Step 2: Verify import**
+- [x] **Step 2: Verify import**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run python -c "from bede_core.main import main; print('OK')"`
 Expected: prints "OK" without error.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -2236,7 +2236,7 @@ git commit -m "feat(bede-core): main entrypoint wiring all components"
 
 bede-core needs Claude CLI installed in the image (unlike bede-data/bede-data-mcp which are pure Python). We also need SSH for vault git access. MCP servers (workspace-mcp, browser-mcp) run as separate sidecar containers — they are NOT part of this image.
 
-- [ ] **Step 1: Create the Dockerfile**
+- [x] **Step 1: Create the Dockerfile**
 
 ```dockerfile
 # bede-core/Dockerfile
@@ -2275,7 +2275,7 @@ EXPOSE 8080
 ENTRYPOINT ["scripts/entrypoint.sh"]
 ```
 
-- [ ] **Step 2: Create the entrypoint script**
+- [x] **Step 2: Create the entrypoint script**
 
 Create `bede-core/scripts/entrypoint.sh`:
 
@@ -2311,7 +2311,7 @@ echo "[entrypoint] Starting bede-core..."
 exec uv run python -m bede_core.main
 ```
 
-- [ ] **Step 3: Create `__main__.py`**
+- [x] **Step 3: Create `__main__.py`**
 
 Create `bede-core/src/bede_core/__main__.py`:
 
@@ -2321,7 +2321,7 @@ from bede_core.main import main
 main()
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -2338,7 +2338,7 @@ git commit -m "feat(bede-core): dockerfile with claude CLI, health endpoint, and
 
 Follow the same pattern as `bede-data-ci.yml` and `bede-data-mcp-ci.yml`: lint, test, then build-push on main.
 
-- [ ] **Step 1: Create the workflow**
+- [x] **Step 1: Create the workflow**
 
 ```yaml
 # .github/workflows/bede-core-ci.yml
@@ -2406,7 +2406,7 @@ jobs:
           cache-to: type=gha,mode=max
 ```
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -2424,7 +2424,7 @@ git commit -m "ci(bede-core): lint, test, build-push workflow"
 
 Add bede-core as a container to the Docker Compose stack. It replaces the prototype `bede` service. The workspace-mcp and browser-mcp sidecars use their own dedicated images (not bede-core's image) — their Dockerfiles are out of scope for this plan but the compose wiring is included.
 
-- [ ] **Step 1: Add bede-core and MCP sidecars to docker-compose.ai.yml**
+- [x] **Step 1: Add bede-core and MCP sidecars to docker-compose.ai.yml**
 
 Add a `bede-core` service to `docker-compose.ai.yml`. Keep the existing `bede` service with `profiles: [disabled]` until migration is complete. Add workspace-mcp and browser-mcp as sidecar containers.
 
@@ -2502,12 +2502,12 @@ Add a `bede-core` service to `docker-compose.ai.yml`. Keep the existing `bede` s
       - homeserver
 ```
 
-- [ ] **Step 2: Verify compose config**
+- [x] **Step 2: Verify compose config**
 
 Run: `cd /Users/joeradford/dev/home-server-stack && make validate`
 Expected: PASS — config is valid.
 
-- [ ] **Step 3: Commit (in home-server-stack repo)**
+- [x] **Step 3: Commit (in home-server-stack repo)**
 
 ```bash
 cd /Users/joeradford/dev/home-server-stack
@@ -2524,7 +2524,7 @@ git commit -m "feat: add bede-core, workspace-mcp, browser-mcp to docker compose
 
 bede-core needs an MCP config file that tells Claude CLI where to find the MCP servers (bede-data-mcp, workspace-mcp, browser-mcp). This file is read by Claude CLI via `--mcp-config`.
 
-- [ ] **Step 1: Create the MCP config**
+- [x] **Step 1: Create the MCP config**
 
 ```json
 {
@@ -2547,7 +2547,7 @@ bede-core needs an MCP config file that tells Claude CLI where to find the MCP s
 
 Note: The exact URL paths depend on how each MCP server exposes its streamable-http endpoint. Verify against bede-data-mcp's `__main__.py` which uses `mcp.run(transport="streamable-http")` — FastMCP's default path is `/mcp/`.
 
-- [ ] **Step 2: Update config.py to reference MCP config**
+- [x] **Step 2: Update config.py to reference MCP config**
 
 Add to `Settings` in `bede-core/src/bede_core/config.py`:
 
@@ -2555,7 +2555,7 @@ Add to `Settings` in `bede-core/src/bede_core/config.py`:
     mcp_config_path: str = "/app/mcp.json"
 ```
 
-- [ ] **Step 3: Update ClaudeCli instantiation in main.py**
+- [x] **Step 3: Update ClaudeCli instantiation in main.py**
 
 In `bede-core/src/bede_core/main.py`, update the `ClaudeCli` constructor:
 
@@ -2568,7 +2568,7 @@ In `bede-core/src/bede_core/main.py`, update the `ClaudeCli` constructor:
     )
 ```
 
-- [ ] **Step 4: Add mcp.json COPY to Dockerfile**
+- [x] **Step 4: Add mcp.json COPY to Dockerfile**
 
 In `bede-core/Dockerfile`, add after the `COPY src/ src/` line:
 
@@ -2576,7 +2576,7 @@ In `bede-core/Dockerfile`, add after the `COPY src/ src/` line:
 COPY mcp.json .
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cd /Users/joeradford/dev/bede
@@ -2592,16 +2592,16 @@ git commit -m "feat(bede-core): MCP config for data, workspace, and browser serv
 - Modify: `/Users/joeradford/dev/home-server-stack/SERVICES.md`
 - Create: `bede-core/README.md` (brief, optional)
 
-- [ ] **Step 1: Update SERVICES.md**
+- [x] **Step 1: Update SERVICES.md**
 
 Add bede-core to the services documentation with its purpose, port, and relationship to other bede services.
 
-- [ ] **Step 2: Run full test suite**
+- [x] **Step 2: Run full test suite**
 
 Run: `cd /Users/joeradford/dev/bede/bede-core && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run pytest tests/ -v`
 Expected: PASS — all lint and tests pass.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 cd /Users/joeradford/dev/home-server-stack


### PR DESCRIPTION
## Summary

- Add `OWNTRACKS_URL`, `OWNTRACKS_USER`, `OWNTRACKS_DEVICE` env vars and `location` network to bede-data so it can reach the OwnTracks recorder
- Update `make bede-pull` to pull all four bede images (bede, bede-data, bede-data-mcp, bede-core) instead of just the legacy one
- Update bede-core plan docs with progress checkboxes

## Related

- josephradford/bede#45 fixes the bede-data location API code (date format + timezone handling) — needs the compose changes here to work end-to-end

## Test plan

- [x] `make validate` passes
- [ ] Deploy to test server, verify bede-data can reach OwnTracks
- [ ] `make bede-pull` pulls all four images

🤖 Generated with [Claude Code](https://claude.com/claude-code)