### PR TITLE
feat: wire bede-workspace-mcp into docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -252,6 +252,19 @@ BEDE_TASKS_PATH=Bede/scheduled-tasks.md
 CLAUDE_MODEL=claude-haiku-4-5-20251001
 
 # -----------------------------------------------------------------------------
+# Google Workspace MCP (workspace-mcp sidecar — Gmail, Calendar, Tasks, Docs)
+# Provides Google Workspace access to Bede via MCP tools.
+# OAuth callback route: https://mcp.DOMAIN/oauth2callback
+# Requires a Google Cloud project with OAuth 2.0 credentials.
+# See: https://console.cloud.google.com/apis/credentials
+# Enable these APIs: Gmail, Calendar, Tasks, Drive, Docs, Sheets, Slides
+# Set authorised redirect URI to: https://mcp.DOMAIN/oauth2callback
+# -----------------------------------------------------------------------------
+GOOGLE_OAUTH_CLIENT_ID=your_google_oauth_client_id_here
+GOOGLE_OAUTH_CLIENT_SECRET=your_google_oauth_client_secret_here
+USER_GOOGLE_EMAIL=your_google_email@gmail.com
+
+# -----------------------------------------------------------------------------
 # Data Ingest (data-ingest — receives health + vault data, writes to SQLite)
 # Replaces hae-server + vault CSV git pipeline.
 # Receives POSTs from iPhone HAE app and Mac nightly export.

--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,7 @@ bede-pull: env-check
 	@docker pull ghcr.io/josephradford/bede-data:latest
 	@docker pull ghcr.io/josephradford/bede-data-mcp:latest
 	@docker pull ghcr.io/josephradford/bede-core:latest
+	@docker pull ghcr.io/josephradford/bede-workspace-mcp:latest
 	@echo "✓ Bede images pulled"
 
 bede-start: env-check

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -124,6 +124,12 @@ Currently deployed and active services.
 - **Access:** Internal only (container-to-container, port 8002)
 - **Image:** `ghcr.io/josephradford/bede-data-mcp:latest`
 
+#### bede-workspace-mcp
+- **Purpose:** Google Workspace MCP sidecar — wraps the `workspace-mcp` PyPI package to provide Gmail, Calendar, Tasks, Docs, Sheets, Slides, and Drive access to Claude inside bede-core
+- **Access:** Internal MCP on port 8003, OAuth callback at https://mcp.${DOMAIN}/oauth2callback (admin-secure, no rate limit)
+- **Image:** `ghcr.io/josephradford/bede-workspace-mcp:latest`
+- **Depends on:** Google OAuth credentials in `.env`
+
 ### Location Services
 
 #### owntracks-recorder
@@ -165,6 +171,7 @@ Currently deployed and active services.
 | bede-core | Telegram bot | N/A |
 | bede-data | https://data.${DOMAIN} | N/A |
 | bede-data-mcp | Internal only | N/A |
+| bede-workspace-mcp | https://mcp.${DOMAIN} (OAuth only) | N/A |
 | owntracks-recorder | https://owntracks.${DOMAIN} | N/A |
 | hae-server | https://hae.${DOMAIN} | N/A |
 | hae-influxdb | https://influxdb.${DOMAIN} | N/A |

--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -263,6 +263,13 @@
           server: my-docker
           showStats: true
 
+      - Bede Workspace MCP:
+          icon: mdi-google
+          description: Google Workspace MCP (Gmail, Calendar, Tasks)
+          container: bede-workspace-mcp
+          server: my-docker
+          showStats: true
+
   # Location Services - Location tracking
   - Location:
       - OwnTracks:

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -48,6 +48,38 @@ services:
       timeout: 5s
       retries: 3
 
+  bede-workspace-mcp:
+    image: ghcr.io/josephradford/bede-workspace-mcp:latest
+    container_name: bede-workspace-mcp
+    restart: unless-stopped
+    environment:
+      - WORKSPACE_MCP_PORT=8003
+      - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID}
+      - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET}
+      - GOOGLE_OAUTH_REDIRECT_URI=https://mcp.${DOMAIN}/oauth2callback
+      - GOOGLE_MCP_CREDENTIALS_DIR=/data/workspace-mcp/credentials
+      - WORKSPACE_MCP_OAUTH_PROXY_STORAGE_BACKEND=disk
+      - WORKSPACE_MCP_OAUTH_PROXY_DISK_DIRECTORY=/data/workspace-mcp/oauth-proxy
+      - MCP_SINGLE_USER_MODE=true
+      - USER_GOOGLE_EMAIL=${USER_GOOGLE_EMAIL}
+    volumes:
+      - ./data/bede:/data
+    networks:
+      - homeserver
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('localhost', 8003), timeout=5); s.close()"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.workspace-mcp.rule=Host(`mcp.${DOMAIN}`)"
+      - "traefik.http.routers.workspace-mcp.entrypoints=websecure"
+      - "traefik.http.routers.workspace-mcp.tls=true"
+      - "traefik.http.routers.workspace-mcp.middlewares=admin-secure-no-ratelimit@docker"
+      - "traefik.http.routers.workspace-mcp.service=workspace-mcp"
+      - "traefik.http.services.workspace-mcp.loadbalancer.server.port=8003"
+
   bede-core:
     image: ghcr.io/josephradford/bede-core:latest
     container_name: bede-core
@@ -77,6 +109,8 @@ services:
       bede-data:
         condition: service_healthy
       bede-data-mcp:
+        condition: service_healthy
+      bede-workspace-mcp:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]


### PR DESCRIPTION
## Summary
- Add bede-workspace-mcp service to docker-compose.ai.yml with Traefik labels for OAuth callback
- Add Google OAuth env vars (CLIENT_ID, CLIENT_SECRET, USER_EMAIL) to .env.example
- Add workspace-mcp to bede-pull Makefile target
- Add to homepage dashboard and SERVICES.md
- Update bede-core depends_on to wait for workspace-mcp healthcheck

## Context
Companion to josephradford/bede PR adding the bede-workspace-mcp Docker image. The image wraps the `workspace-mcp` PyPI package (Google Workspace MCP server). Once both PRs are merged and the GHCR image is built, deploy with `make bede-pull && make bede-restart`.

## Test plan
- [ ] `make validate` passes
- [ ] After deploy: `make bede-status` shows workspace-mcp healthy
- [ ] OAuth flow works: visit https://mcp.DOMAIN/oauth2callback triggers Google consent
- [ ] bede-core can reach workspace-mcp MCP tools (check bede-core logs for MCP discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)