### PR TITLE
fix: pin bede-data traefik routing to homeserver network

### DIFF
--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -29,6 +29,7 @@ services:
       - "traefik.http.routers.data-ingest.middlewares=webhook-secure@docker"
       - "traefik.http.routers.data-ingest.service=data-ingest"
       - "traefik.http.services.data-ingest.loadbalancer.server.port=8001"
+      - "traefik.docker.network=home-server-stack_homeserver"
 
   bede-data-mcp:
     image: ghcr.io/josephradford/bede-data-mcp:latest


### PR DESCRIPTION
## Summary

- Add `traefik.docker.network=home-server-stack_homeserver` label to bede-data service
- bede-data is on both `homeserver` and `location` networks; without this label, Traefik may resolve to the `location` network IP which it can't reach, causing 504 Gateway Timeout on the data ingest endpoint

## Test plan

- [ ] Deploy to server and verify `make test-domain-access` passes for data endpoint
- [ ] Restart bede-data multiple times and confirm Traefik routing remains stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)