### PR TITLE
chore: pin all Docker images to specific versions

### DIFF
--- a/docker-compose.dashboard.yml
+++ b/docker-compose.dashboard.yml
@@ -35,7 +35,7 @@ services:
       - "traefik.http.routers.homepage-api.middlewares=admin-secure"
 
   homepage:
-    image: ghcr.io/gethomepage/homepage:latest
+    image: ghcr.io/gethomepage/homepage:v1.12.3
     container_name: homepage
     environment:
       PUID: ${PUID:-1000}

--- a/docker-compose.location.yml
+++ b/docker-compose.location.yml
@@ -15,7 +15,7 @@
 
 services:
   mosquitto:
-    image: eclipse-mosquitto
+    image: eclipse-mosquitto:2.1.2
     container_name: mosquitto
     restart: unless-stopped
     # No config needed — default settings allow anonymous connections on 1883
@@ -23,7 +23,7 @@ services:
       - location
 
   owntracks-recorder:
-    image: owntracks/recorder
+    image: owntracks/recorder:1.0.1
     container_name: owntracks-recorder
     restart: unless-stopped
     environment:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,6 +1,6 @@
 services:
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.11.3
     container_name: prometheus
     restart: unless-stopped
     ports:
@@ -28,7 +28,7 @@ services:
       - "traefik.http.routers.prometheus.middlewares=admin-secure"
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.4.3
     container_name: grafana
     restart: unless-stopped
     expose:
@@ -53,7 +53,7 @@ services:
       - "traefik.http.routers.grafana.middlewares=admin-secure-no-ratelimit"
 
   alertmanager:
-    image: prom/alertmanager:latest
+    image: prom/alertmanager:v0.32.1
     container_name: alertmanager
     restart: unless-stopped
     ports:
@@ -73,7 +73,7 @@ services:
       - "traefik.http.routers.alertmanager.middlewares=admin-secure"
 
   node-exporter:
-    image: prom/node-exporter:latest
+    image: prom/node-exporter:v1.11.1
     container_name: node-exporter
     restart: unless-stopped
     ports:
@@ -91,7 +91,7 @@ services:
       - homeserver
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.47.2
+    image: gcr.io/cadvisor/cadvisor:v0.56.2
     container_name: cadvisor
     restart: unless-stopped
     ports:

--- a/docker-compose.network.yml
+++ b/docker-compose.network.yml
@@ -13,8 +13,9 @@ services:
   # Note: Using v3.6.2+ which includes Docker API compatibility fix for Docker 29.x+
   # Previous versions (v3.2-v3.6.1) had embedded Docker client API v1.24 incompatibility
   # Fixed in v3.6.2 via auto-negotiation (GitHub issue #12253, PR #12256)
+  # Pinned to v3.6.16 (latest patch on v3.6.x line)
   traefik:
-    image: traefik:v3.6.2
+    image: traefik:v3.6.16
     container_name: traefik
     restart: unless-stopped
     command:
@@ -133,7 +134,7 @@ services:
 
   # Fail2ban - Protection against brute force and scanning attempts
   fail2ban:
-    image: crazymax/fail2ban:latest
+    image: crazymax/fail2ban:1.1.0
     container_name: fail2ban
     restart: unless-stopped
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 
 services:
   adguard:
-    image: adguard/adguardhome:latest
+    image: adguard/adguardhome:v0.107.74
     container_name: adguard-home
     restart: unless-stopped
     ports:
@@ -31,7 +31,7 @@ services:
       - "traefik.http.routers.adguard.middlewares=admin-secure-no-ratelimit"
 
   n8n-init:
-    image: alpine:latest
+    image: alpine:3.22.4
     container_name: n8n-init
     restart: "no"
     volumes:
@@ -44,7 +44,7 @@ services:
       "
 
   n8n:
-    image: n8nio/n8n:latest
+    image: n8nio/n8n:2.20.0
     container_name: n8n
     restart: unless-stopped
     user: "1000:1000"

--- a/docs/superpowers/specs/2026-05-06-pin-docker-images-design.md
+++ b/docs/superpowers/specs/2026-05-06-pin-docker-images-design.md
@@ -1,0 +1,52 @@
+# Pin All Docker Images to Specific Versions
+
+**Date:** 2026-05-06
+**Issue:** #181
+
+## Problem
+
+Several Docker images use `:latest` or are untagged, making deploys non-deterministic. `make update` can silently pull breaking changes.
+
+## Version Map
+
+| Image | Current | Pin to |
+|-------|---------|--------|
+| `adguard/adguardhome` | `:latest` | `v0.107.74` |
+| `alpine` | `:latest` | `3.22.4` |
+| `n8nio/n8n` | `:latest` | `2.20.0` |
+| `prom/prometheus` | `:latest` | `v3.11.3` |
+| `grafana/grafana` | `:latest` | `12.4.3` |
+| `prom/alertmanager` | `:latest` | `v0.32.1` |
+| `prom/node-exporter` | `:latest` | `v1.11.1` |
+| `gcr.io/cadvisor/cadvisor` | `v0.47.2` | `v0.56.2` |
+| `traefik` | `v3.6.2` | `v3.6.16` |
+| `crazymax/fail2ban` | `:latest` | `1.1.0` |
+| `ghcr.io/gethomepage/homepage` | `:latest` | `v1.12.3` |
+| `eclipse-mosquitto` | (no tag) | `2.1.2` |
+| `owntracks/recorder` | (no tag) | `1.0.1` |
+| `ghcr.io/astral-sh/uv` (bede) | `python3.12-bookworm-slim` | `0.11.10-python3.12-bookworm-slim` |
+| `ghcr.io/josephradford/bede-*` | `:latest` | Keep `:latest` |
+
+Conservative choices: Grafana stays on 12.x (skip 13.x major bump), Traefik stays on 3.6.x patch line.
+
+## Files to Change
+
+### home-server-stack
+
+- `docker-compose.yml` — adguard, alpine, n8n
+- `docker-compose.network.yml` — traefik, fail2ban
+- `docker-compose.monitoring.yml` — prometheus, grafana, alertmanager, node-exporter, cadvisor
+- `docker-compose.dashboard.yml` — homepage
+- `docker-compose.location.yml` — mosquitto, owntracks
+
+### bede repo
+
+- `bede-data/Dockerfile` — uv base image
+- `bede-data-mcp/Dockerfile` — uv base image
+- `bede-workspace-mcp/Dockerfile` — uv base image
+- `bede-core/Dockerfile` — uv base image
+
+## Validation
+
+1. `make validate` locally
+2. Deploy to server and run `make status` + `make test-domain-access`


### PR DESCRIPTION
## Summary

Closes #181

- Pin 11 unpinned images (`:latest` or no tag) to current stable versions
- Bump traefik `v3.6.2` → `v3.6.16` (latest patch on 3.6.x line)
- Bump cadvisor `v0.47.2` → `v0.56.2`
- Grafana pinned conservatively to `12.4.3` (skip 13.x major bump)
- Bede images intentionally kept on `:latest` (own images, always want latest build)

## Test plan

- [x] `make validate` passes locally
- [ ] Deploy to server: `make update && make status`
- [ ] `make test-domain-access` passes
- [ ] Spot-check key services (Homepage, Grafana, AdGuard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)