### PR TITLE
fix: correct cadvisor registry and mosquitto tag

### DIFF
--- a/docker-compose.location.yml
+++ b/docker-compose.location.yml
@@ -15,7 +15,7 @@
 
 services:
   mosquitto:
-    image: eclipse-mosquitto:2.1.2
+    image: eclipse-mosquitto:2.0.22
     container_name: mosquitto
     restart: unless-stopped
     # No config needed — default settings allow anonymous connections on 1883

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -91,7 +91,7 @@ services:
       - homeserver
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.56.2
+    image: ghcr.io/google/cadvisor:0.56.2
     container_name: cadvisor
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary

Fixes two broken image references from #183:

- **cAdvisor**: moved from `gcr.io` to `ghcr.io/google/cadvisor` at v0.53.0 (no `v` prefix)
- **Mosquitto**: 2.1.x only publishes Alpine images; pinned to `2.0.22` (latest Debian)

## Test plan

- [x] `make validate` passes
- [ ] `make update` pulls both images successfully
- [ ] `make status` shows cadvisor and mosquitto healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)