### PR TITLE
fix: add mosquitto config for 2.0+ network listener

### DIFF
--- a/config/mosquitto/mosquitto.conf
+++ b/config/mosquitto/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/docker-compose.location.yml
+++ b/docker-compose.location.yml
@@ -18,7 +18,8 @@ services:
     image: eclipse-mosquitto:2.0.22
     container_name: mosquitto
     restart: unless-stopped
-    # No config needed — default settings allow anonymous connections on 1883
+    volumes:
+      - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
     networks:
       - location
 


### PR DESCRIPTION
## Summary

Mosquitto 2.0+ changed the default to localhost-only connections, breaking owntracks-recorder which connects over the Docker network. Adds a minimal config with `listener 1883` and `allow_anonymous true`.

Discovered during deploy of #183 (image pinning).

## Test plan

- [x] `make validate` passes
- [ ] `make update` on server
- [ ] owntracks-recorder stops restart-looping and connects to mosquitto

🤖 Generated with [Claude Code](https://claude.com/claude-code)