### PR TITLE
refactor: remove mosquitto, run owntracks in HTTP-only mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,11 +63,8 @@ graph TB
     subgraph Location["Location Services
     docker-compose.location.yml"]
         OwnTracks["owntracks-recorder
-        Location API
+        Location API (HTTP-only)
         :8083"]
-        Mosquitto["mosquitto
-        MQTT sidecar
-        :1883 (internal)"]
     end
 
     subgraph Monitoring["Monitoring Stack
@@ -154,7 +151,7 @@ graph TB
     Bede -->|Telegram Bot API| Internet
     Bede -.->|MCP Protocol| DataMCP
     DataMCP -->|Reads| OwnTracks
-    OwnTracks -->|Publishes via sidecar| Mosquitto
+    OwnTracks -->|HTTP POST /pub| OwnTracks
 
     %% Certificate management
     Certbot -->|Copies Certs| TraefikData
@@ -249,7 +246,7 @@ graph TB
         owntracks-recorder"]
         Internal["Internal-Only Services
         bede (Telegram outbound)
-        data-mcp, mosquitto
+        data-mcp
         node-exporter, cadvisor"]
         Webhooks["Public Webhooks
         Future"]
@@ -366,9 +363,6 @@ graph TD
     Personal Data MCP"]
     OwnTracks["owntracks-recorder
     Location API"]
-    Mosquitto["mosquitto
-    MQTT sidecar"]
-
     %% Dependencies
     Docker --> Traefik
     Docker --> Fail2ban
@@ -384,7 +378,6 @@ graph TD
     Docker --> Bede
     Docker --> DataMCP
     Docker --> OwnTracks
-    Docker --> Mosquitto
 
     Traefik --> N8N
     Traefik --> Grafana
@@ -401,7 +394,6 @@ graph TD
     Prometheus --> Alertmanager
 
     HomepageAPI --> Homepage
-    Mosquitto --> OwnTracks
     OwnTracks --> DataMCP
     DataMCP --> Bede
 
@@ -424,7 +416,7 @@ graph TD
     class AdGuard,N8NInit,N8N core
     class Prometheus,NodeExporter,CAdvisor,Grafana,Alertmanager monitoring
     class HomepageAPI,Homepage dashboard
-    class Bede,DataMCP,OwnTracks,Mosquitto ai
+    class Bede,DataMCP,OwnTracks ai
 ```
 
 ---
@@ -554,7 +546,7 @@ The stack uses multiple compose files for logical separation:
 - **docker-compose.monitoring.yml**: Monitoring stack (Prometheus, Grafana, Alertmanager, exporters)
 - **docker-compose.dashboard.yml**: Dashboard (Homepage, Homepage API)
 - **docker-compose.ai.yml**: AI assistant services (Bede, data-mcp)
-- **docker-compose.location.yml**: Location stack (owntracks-recorder, mosquitto)
+- **docker-compose.location.yml**: Location stack (owntracks-recorder)
 
 ### Domain-Based Routing
 All services accessible via `https://<service>.${DOMAIN}`:

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -137,10 +137,6 @@ Currently deployed and active services.
 - **Access:** https://owntracks.${DOMAIN}
 - **Authentication:** IP-restricted via Traefik `admin-secure`
 
-#### mosquitto
-- **Purpose:** Internal MQTT broker sidecar required by owntracks-recorder
-- **Access:** Internal only
-- **Authentication:** Internal network-only usage in this stack
 
 ### Health Services
 

--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -283,10 +283,3 @@
           container: owntracks-recorder
           server: my-docker
           showStats: true
-
-      - Mosquitto:
-          icon: mdi-access-point
-          description: MQTT broker (internal)
-          container: mosquitto
-          server: my-docker
-          showStats: true

--- a/config/mosquitto/mosquitto.conf
+++ b/config/mosquitto/mosquitto.conf
@@ -1,2 +1,0 @@
-listener 1883
-allow_anonymous true

--- a/docker-compose.location.yml
+++ b/docker-compose.location.yml
@@ -1,10 +1,7 @@
 ---
 # Location Services
-# This file contains location tracking services.
-# - mosquitto:          Minimal MQTT broker required internally by owntracks-recorder.
-#                       Not exposed outside the stack. iOS app does NOT use MQTT.
 # - owntracks-recorder: Receives OwnTracks HTTP POSTs and exposes a REST read API.
-#                       iOS app POSTs directly over HTTP — no MQTT config on iPhone.
+#                       Runs in HTTP-only mode (MQTT disabled via OTR_PORT=0).
 #
 # iPhone setup: In OwnTracks app, set mode to HTTP and destination to:
 #   URL:  https://owntracks.DOMAIN/pub
@@ -14,30 +11,20 @@
 #           Returns raw lat/lng points. Resolve place names via Nominatim at query time.
 
 services:
-  mosquitto:
-    image: eclipse-mosquitto:2.0.22
-    container_name: mosquitto
-    restart: unless-stopped
-    volumes:
-      - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
-    networks:
-      - location
-
   owntracks-recorder:
     image: owntracks/recorder:1.0.1
     container_name: owntracks-recorder
     restart: unless-stopped
     environment:
-      OTR_HOST: mosquitto
+      OTR_PORT: "0"
+      OTR_HTTPHOST: "0.0.0.0"
+      OTR_HTTPPORT: "8083"
     volumes:
       - ./data/owntracks/store:/store
       - ./data/owntracks/config:/config
     expose:
       - 8083
-    depends_on:
-      - mosquitto
     networks:
-      - location
       - homeserver
     labels:
       - "traefik.enable=true"
@@ -46,11 +33,8 @@ services:
       - "traefik.http.routers.owntracks.tls=true"
       - "traefik.http.services.owntracks.loadbalancer.server.port=8083"
       - "traefik.http.routers.owntracks.middlewares=admin-secure@docker"
-      - "traefik.docker.network=home-server-stack_homeserver"
 
 networks:
-  location:
-    name: home-server-stack_location
   homeserver:
     external: true
     name: home-server-stack_homeserver

--- a/docs/superpowers/plans/2026-05-06-bede-web.md
+++ b/docs/superpowers/plans/2026-05-06-bede-web.md
@@ -1,0 +1,1616 @@
+# bede-web Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build bede-web — a read-only operational dashboard and data browser for the Bede personal assistant, served as static files by nginx with an API proxy to bede-data.
+
+**Architecture:** Multi-stage Docker image (Node + Vite build → nginx:alpine serve). Static HTML pages with Tailwind CSS and Alpine.js for light interactivity. nginx reverse-proxies `/api/*` to bede-data:8001. Five pages: dashboard (2×2 card grid), tasks, memories, goals, conversations. Dark theme with status colours.
+
+**Tech Stack:** Vite, Tailwind CSS, Alpine.js, marked, DOMPurify, nginx, Docker, GitHub Actions
+
+**Repos:**
+- **bede** (`/Users/joeradford/dev/bede`) — bede-web source code, Dockerfile, CI workflow, bede-data prerequisite
+- **home-server-stack** (`/Users/joeradford/dev/home-server-stack`) — compose wiring, Makefile, homepage, docs
+
+**Specs:** [bede-web Design](../specs/2026-05-06-bede-web-design.md) · [Bede Design](../specs/2026-04-29-bede-design.md) §2.3
+
+---
+
+## File Structure
+
+### bede repo (`/Users/joeradford/dev/bede`)
+
+```
+bede-web/
+├── Dockerfile              # multi-stage: node build → nginx:alpine
+├── nginx.conf              # serve static + proxy /api → bede-data:8001
+├── package.json            # vite, tailwindcss, alpinejs, marked, dompurify
+├── vite.config.js          # multi-page build, HTML partials
+├── tailwind.config.js      # dark theme colours
+├── postcss.config.js       # tailwind + autoprefixer
+├── src/
+│   ├── index.html          # dashboard (2×2 card grid)
+│   ├── tasks.html          # task execution history
+│   ├── memories.html       # memory browser
+│   ├── goals.html          # goal progress
+│   ├── conversations.html  # conversation history
+│   ├── partials/
+│   │   └── nav.html        # shared navigation bar
+│   ├── css/
+│   │   └── app.css         # Tailwind directives + custom utilities
+│   └── js/
+│       └── app.js          # Alpine.js init, fetch helper, shared logic
+├── .github/workflows/
+│   └── bede-web-ci.yml     # build → push GHCR image
+
+bede-data/
+├── src/bede_data/api/task_log.py  # Modified: add since/until params
+└── tests/test_api_task_log.py     # Modified: add date filter tests
+```
+
+### home-server-stack repo (`/Users/joeradford/dev/home-server-stack`)
+
+```
+docker-compose.ai.yml                   # Add bede-web service
+.env.example                            # (no new vars needed)
+config/homepage/services-template.yaml  # Add bede-web entry
+SERVICES.md                             # Document bede-web
+Makefile                                # Add bede-web to bede-pull
+```
+
+---
+
+### Task 1: bede-data Prerequisite — Date Range Filter on Task History (bede repo)
+
+**Files:**
+- Modify: `/Users/joeradford/dev/bede/bede-data/src/bede_data/api/task_log.py`
+- Modify: `/Users/joeradford/dev/bede/bede-data/tests/test_api_task_log.py`
+
+- [ ] **Step 1: Write test for `since` filter**
+
+Add to the end of `bede-data/tests/test_api_task_log.py`:
+
+```python
+def test_get_task_history_filter_since(client):
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-28T08:00:00Z",
+            "status": "success",
+        },
+    )
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-29T08:00:00Z",
+            "status": "success",
+        },
+    )
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Evening Reflection",
+            "start_time": "2026-04-30T21:00:00Z",
+            "status": "success",
+        },
+    )
+
+    response = client.get(
+        "/api/tasks/history", params={"since": "2026-04-29T00:00:00Z"}
+    )
+    assert response.status_code == 200
+    execs = response.json()["executions"]
+    assert len(execs) == 2
+    assert all(e["start_time"] >= "2026-04-29T00:00:00Z" for e in execs)
+
+
+def test_get_task_history_filter_until(client):
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-28T08:00:00Z",
+            "status": "success",
+        },
+    )
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-29T08:00:00Z",
+            "status": "success",
+        },
+    )
+
+    response = client.get(
+        "/api/tasks/history", params={"until": "2026-04-28T23:59:59Z"}
+    )
+    assert response.status_code == 200
+    execs = response.json()["executions"]
+    assert len(execs) == 1
+    assert execs[0]["start_time"] == "2026-04-28T08:00:00Z"
+
+
+def test_get_task_history_filter_since_and_until(client):
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "A",
+            "start_time": "2026-04-27T08:00:00Z",
+            "status": "success",
+        },
+    )
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "B",
+            "start_time": "2026-04-28T08:00:00Z",
+            "status": "success",
+        },
+    )
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "C",
+            "start_time": "2026-04-29T08:00:00Z",
+            "status": "success",
+        },
+    )
+
+    response = client.get(
+        "/api/tasks/history",
+        params={"since": "2026-04-28T00:00:00Z", "until": "2026-04-28T23:59:59Z"},
+    )
+    assert response.status_code == 200
+    execs = response.json()["executions"]
+    assert len(execs) == 1
+    assert execs[0]["task_name"] == "B"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/joeradford/dev/bede/bede-data && uv run pytest tests/test_api_task_log.py -v -k "since or until"`
+Expected: FAIL — `since` and `until` params are ignored, all rows returned.
+
+- [ ] **Step 3: Implement date range filtering**
+
+Replace the `get_task_history` function in `bede-data/src/bede_data/api/task_log.py`:
+
+```python
+@router.get("/history")
+def get_task_history(
+    task_name: str | None = Query(None),
+    since: str | None = Query(None),
+    until: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, task_name, start_time, end_time, duration_seconds, status, error_detail, created_at FROM task_executions WHERE 1=1"
+    params: list = []
+    if task_name:
+        query += " AND task_name = ?"
+        params.append(task_name)
+    if since:
+        query += " AND start_time >= ?"
+        params.append(since)
+    if until:
+        query += " AND start_time <= ?"
+        params.append(until)
+    query += " ORDER BY start_time DESC LIMIT ?"
+    params.append(limit)
+    cursor = conn.execute(query, params)
+    return {"executions": [dict(row) for row in cursor.fetchall()]}
+```
+
+- [ ] **Step 4: Run all task_log tests**
+
+Run: `cd /Users/joeradford/dev/bede/bede-data && uv run pytest tests/test_api_task_log.py -v`
+Expected: All tests PASS (existing + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-data/src/bede_data/api/task_log.py bede-data/tests/test_api_task_log.py
+git commit -m "feat(bede-data): add since/until date filters to task history endpoint"
+```
+
+---
+
+### Task 2: Project Scaffold (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/package.json`
+- Create: `/Users/joeradford/dev/bede/bede-web/vite.config.js`
+- Create: `/Users/joeradford/dev/bede/bede-web/tailwind.config.js`
+- Create: `/Users/joeradford/dev/bede/bede-web/postcss.config.js`
+- Create: `/Users/joeradford/dev/bede/bede-web/src/css/app.css`
+- Create: `/Users/joeradford/dev/bede/bede-web/src/js/app.js`
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "bede-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "alpinejs": "^3.14.0",
+    "dompurify": "^3.1.0",
+    "marked": "^15.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.5.0",
+    "tailwindcss": "^4.1.0",
+    "vite": "^6.3.0",
+    "vite-plugin-html-inject": "^1.1.0"
+  }
+}
+```
+
+Note: `vite-plugin-html-inject` handles the shared nav partial — it replaces `<load src="partials/nav.html" />` tags with the file content at build time.
+
+- [ ] **Step 2: Create vite.config.js**
+
+```js
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import { htmlInjectionPlugin } from "vite-plugin-html-inject";
+
+export default defineConfig({
+  root: "src",
+  plugins: [htmlInjectionPlugin()],
+  build: {
+    outDir: "../dist",
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, "src/index.html"),
+        tasks: resolve(__dirname, "src/tasks.html"),
+        memories: resolve(__dirname, "src/memories.html"),
+        goals: resolve(__dirname, "src/goals.html"),
+        conversations: resolve(__dirname, "src/conversations.html"),
+      },
+    },
+  },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:8001",
+        changeOrigin: true,
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 3: Create tailwind.config.js**
+
+```js
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./src/**/*.{html,js}"],
+  theme: {
+    extend: {
+      colors: {
+        surface: {
+          bg: "#0f1923",
+          card: "#1a2332",
+          border: "#2a3a4a",
+        },
+        status: {
+          ok: "#6ee7b7",
+          warn: "#fbbf24",
+          error: "#f87171",
+          pending: "#93c5fd",
+        },
+      },
+    },
+  },
+};
+```
+
+- [ ] **Step 4: Create postcss.config.js**
+
+```js
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+    autoprefixer: {},
+  },
+};
+```
+
+- [ ] **Step 5: Create src/css/app.css**
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-surface-bg: #0f1923;
+  --color-surface-card: #1a2332;
+  --color-surface-border: #2a3a4a;
+  --color-status-ok: #6ee7b7;
+  --color-status-warn: #fbbf24;
+  --color-status-error: #f87171;
+  --color-status-pending: #93c5fd;
+}
+
+body {
+  @apply bg-surface-bg text-gray-200 font-sans;
+}
+```
+
+- [ ] **Step 6: Create src/js/app.js**
+
+```js
+import Alpine from "alpinejs";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+
+window.Alpine = Alpine;
+
+window.renderMarkdown = (md) => {
+  return DOMPurify.sanitize(marked.parse(md || ""));
+};
+
+window.api = async (path) => {
+  try {
+    const res = await fetch(`/api${path}`);
+    if (!res.ok) {
+      return { error: `HTTP ${res.status}`, data: null };
+    }
+    return { error: null, data: await res.json() };
+  } catch (e) {
+    return { error: e.message, data: null };
+  }
+};
+
+Alpine.start();
+```
+
+- [ ] **Step 7: Install dependencies and verify build**
+
+Run: `cd /Users/joeradford/dev/bede/bede-web && npm install`
+Expected: `node_modules/` created, `package-lock.json` generated.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/package.json bede-web/package-lock.json bede-web/vite.config.js bede-web/tailwind.config.js bede-web/postcss.config.js bede-web/src/css/app.css bede-web/src/js/app.js
+git commit -m "feat(bede-web): project scaffold with Vite, Tailwind, Alpine.js"
+```
+
+---
+
+### Task 3: Shared Navigation Partial (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/src/partials/nav.html`
+
+- [ ] **Step 1: Create nav.html**
+
+```html
+<nav class="bg-surface-card border-b border-surface-border px-6 py-3 flex items-center justify-between">
+  <a href="/" class="text-lg font-semibold text-gray-100">Bede</a>
+  <div class="flex gap-6 text-sm">
+    <a href="/" class="nav-link" data-page="index">Dashboard</a>
+    <a href="/tasks.html" class="nav-link" data-page="tasks">Tasks</a>
+    <a href="/memories.html" class="nav-link" data-page="memories">Memories</a>
+    <a href="/goals.html" class="nav-link" data-page="goals">Goals</a>
+    <a href="/conversations.html" class="nav-link" data-page="conversations">Conversations</a>
+  </div>
+</nav>
+<script>
+  document.querySelectorAll(".nav-link").forEach((link) => {
+    const page = link.dataset.page;
+    const current = location.pathname === "/" ? "index" : location.pathname.replace(/^\/|\.html$/g, "");
+    if (page === current) {
+      link.classList.add("text-white", "font-medium");
+    } else {
+      link.classList.add("text-gray-400", "hover:text-gray-200");
+    }
+  });
+</script>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/src/partials/nav.html
+git commit -m "feat(bede-web): shared navigation partial"
+```
+
+---
+
+### Task 4: Dashboard Page (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/src/index.html`
+
+- [ ] **Step 1: Create index.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bede — Dashboard</title>
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body>
+  <load src="partials/nav.html" />
+
+  <main class="max-w-5xl mx-auto p-6" x-data="dashboard()" x-init="init()">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+      <!-- Data Freshness -->
+      <div class="bg-surface-card border border-surface-border rounded-lg p-4">
+        <h2 class="text-xs uppercase text-gray-500 mb-3">Data Freshness</h2>
+        <template x-if="error">
+          <p class="text-status-error text-sm" x-text="error"></p>
+        </template>
+        <div class="space-y-1">
+          <template x-for="src in freshness" :key="src.source">
+            <div class="flex items-center justify-between text-sm">
+              <span class="flex items-center gap-2">
+                <span class="w-2 h-2 rounded-full" :class="freshnessColor(src)"></span>
+                <span x-text="src.source"></span>
+              </span>
+              <span class="text-gray-500 text-xs" x-text="timeAgo(src.last_received_at)"></span>
+            </div>
+          </template>
+        </div>
+        <a href="/tasks.html" class="text-xs text-gray-500 hover:text-gray-300 mt-3 inline-block">View all →</a>
+      </div>
+
+      <!-- Task Status -->
+      <div class="bg-surface-card border border-surface-border rounded-lg p-4">
+        <h2 class="text-xs uppercase text-gray-500 mb-3">Task Status</h2>
+        <template x-if="error">
+          <p class="text-status-error text-sm" x-text="error"></p>
+        </template>
+        <div class="space-y-1">
+          <template x-for="task in recentTasks" :key="task.id">
+            <div class="flex items-center justify-between text-sm">
+              <span x-text="task.task_name"></span>
+              <span class="text-xs" :class="statusColor(task.status)">
+                <span x-text="statusIcon(task.status)"></span>
+                <span x-text="task.status === 'success' ? formatTime(task.start_time) : task.error_detail || task.status"></span>
+              </span>
+            </div>
+          </template>
+        </div>
+        <a href="/tasks.html" class="text-xs text-gray-500 hover:text-gray-300 mt-3 inline-block">View all →</a>
+      </div>
+
+      <!-- Storage -->
+      <div class="bg-surface-card border border-surface-border rounded-lg p-4">
+        <h2 class="text-xs uppercase text-gray-500 mb-3">Storage</h2>
+        <template x-if="error">
+          <p class="text-status-error text-sm" x-text="error"></p>
+        </template>
+        <div x-show="storage">
+          <p class="text-2xl font-semibold" x-text="formatBytes(storage?.db_size_bytes)"></p>
+          <p class="text-xs text-gray-500" x-text="totalRows() + ' rows across ' + (storage?.tables?.length || 0) + ' tables'"></p>
+        </div>
+      </div>
+
+      <!-- Today's Schedule -->
+      <div class="bg-surface-card border border-surface-border rounded-lg p-4">
+        <h2 class="text-xs uppercase text-gray-500 mb-3">Today's Schedule</h2>
+        <template x-if="error">
+          <p class="text-status-error text-sm" x-text="error"></p>
+        </template>
+        <div class="space-y-1">
+          <template x-for="item in schedule" :key="item.task_name">
+            <div class="flex items-center justify-between text-sm">
+              <span>
+                <span x-text="item.completed ? '☑' : '☐'"></span>
+                <span x-text="item.task_name"></span>
+              </span>
+              <span class="text-xs" :class="item.completed ? 'text-gray-500' : 'text-status-pending'" x-text="item.display_time"></span>
+            </div>
+          </template>
+        </div>
+      </div>
+
+    </div>
+
+    <p class="text-center text-xs text-gray-600 mt-4">
+      Last updated: <span x-text="lastUpdated"></span>
+    </p>
+  </main>
+
+  <script type="module" src="/js/app.js"></script>
+  <script>
+    function dashboard() {
+      return {
+        freshness: [],
+        recentTasks: [],
+        storage: null,
+        schedule: [],
+        error: null,
+        lastUpdated: "",
+        refreshInterval: null,
+
+        async init() {
+          await this.refresh();
+          this.refreshInterval = setInterval(() => this.refresh(), 60000);
+        },
+
+        async refresh() {
+          const [freshRes, taskRes, storageRes, schedRes, historyRes] = await Promise.all([
+            api("/freshness"),
+            api("/tasks/history?limit=10"),
+            api("/storage"),
+            api("/config/schedules"),
+            api("/tasks/history?since=" + todayStart()),
+          ]);
+
+          if (freshRes.error || taskRes.error || storageRes.error || schedRes.error) {
+            this.error = freshRes.error || taskRes.error || storageRes.error || schedRes.error;
+            return;
+          }
+
+          this.error = null;
+          this.freshness = freshRes.data.sources;
+          this.recentTasks = taskRes.data.executions;
+          this.storage = storageRes.data;
+
+          const todayExecs = historyRes.data?.executions || [];
+          const completedNames = new Set(todayExecs.filter(e => e.status === "success").map(e => e.task_name));
+          this.schedule = (schedRes.data.schedules || [])
+            .filter(s => s.enabled)
+            .map(s => ({
+              task_name: s.task_name,
+              completed: completedNames.has(s.task_name),
+              display_time: s.cron_expression,
+            }));
+
+          this.lastUpdated = new Date().toLocaleTimeString();
+        },
+
+        freshnessColor(src) {
+          if (!src.last_received_at) return "bg-status-error";
+          const age = (Date.now() - new Date(src.last_received_at).getTime()) / 1000;
+          const expected = src.expected_interval_seconds || 86400;
+          if (age <= expected) return "bg-status-ok";
+          if (age <= expected * 2) return "bg-status-warn";
+          return "bg-status-error";
+        },
+
+        statusColor(status) {
+          if (status === "success") return "text-status-ok";
+          if (status === "failure" || status === "timeout") return "text-status-error";
+          return "text-status-pending";
+        },
+
+        statusIcon(status) {
+          if (status === "success") return "✓";
+          if (status === "failure" || status === "timeout") return "✗";
+          return "⋯";
+        },
+
+        formatTime(ts) {
+          if (!ts) return "";
+          return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+        },
+
+        formatBytes(bytes) {
+          if (!bytes) return "0 B";
+          if (bytes < 1024) return bytes + " B";
+          if (bytes < 1048576) return (bytes / 1024).toFixed(1) + " KB";
+          return (bytes / 1048576).toFixed(1) + " MB";
+        },
+
+        totalRows() {
+          return (this.storage?.tables || []).reduce((sum, t) => sum + t.row_count, 0).toLocaleString();
+        },
+
+        timeAgo(ts) {
+          if (!ts) return "never";
+          const seconds = Math.floor((Date.now() - new Date(ts).getTime()) / 1000);
+          if (seconds < 60) return seconds + "s ago";
+          if (seconds < 3600) return Math.floor(seconds / 60) + "m ago";
+          if (seconds < 86400) return Math.floor(seconds / 3600) + "h ago";
+          return Math.floor(seconds / 86400) + "d ago";
+        },
+      };
+    }
+
+    function todayStart() {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      return d.toISOString();
+    }
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Verify dev server starts**
+
+Run: `cd /Users/joeradford/dev/bede/bede-web && npm run dev`
+Expected: Vite dev server starts on `http://localhost:5173`. Dashboard page loads (API calls will 404 without bede-data running, but the page structure renders).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/src/index.html
+git commit -m "feat(bede-web): dashboard page with 2x2 card grid"
+```
+
+---
+
+### Task 5: Tasks Page (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/src/tasks.html`
+
+- [ ] **Step 1: Create tasks.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bede — Tasks</title>
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body>
+  <load src="partials/nav.html" />
+
+  <main class="max-w-4xl mx-auto p-6" x-data="tasksPage()" x-init="init()">
+    <h1 class="text-xl font-semibold mb-4">Task Execution History</h1>
+
+    <div class="flex flex-wrap gap-3 mb-4">
+      <select x-model="dateRange" @change="refresh()" class="bg-surface-card border border-surface-border rounded px-3 py-1 text-sm text-gray-200">
+        <option value="today">Today</option>
+        <option value="yesterday">Yesterday</option>
+        <option value="7d">Last 7 days</option>
+        <option value="30d">Last 30 days</option>
+      </select>
+      <select x-model="statusFilter" @change="applyFilter()" class="bg-surface-card border border-surface-border rounded px-3 py-1 text-sm text-gray-200">
+        <option value="all">All statuses</option>
+        <option value="success">Success</option>
+        <option value="failure">Failure</option>
+        <option value="timeout">Timeout</option>
+      </select>
+    </div>
+
+    <template x-if="error">
+      <div class="bg-surface-card border border-status-error rounded-lg p-4 text-status-error text-sm" x-text="error"></div>
+    </template>
+
+    <div class="space-y-1">
+      <template x-for="task in filtered" :key="task.id">
+        <div class="bg-surface-card border border-surface-border rounded-lg p-3 text-sm">
+          <div class="flex items-center justify-between cursor-pointer" @click="task._expanded = !task._expanded">
+            <div class="flex items-center gap-3">
+              <span class="w-2 h-2 rounded-full" :class="dotColor(task.status)"></span>
+              <span x-text="task.task_name"></span>
+            </div>
+            <div class="flex items-center gap-4 text-xs text-gray-500">
+              <span x-text="formatDuration(task.duration_seconds)"></span>
+              <span x-text="formatDateTime(task.start_time)"></span>
+            </div>
+          </div>
+          <div x-show="task._expanded" x-cloak class="mt-2 pl-5 text-xs text-gray-400">
+            <p x-show="task.error_detail" class="text-status-error" x-text="task.error_detail"></p>
+            <p>Start: <span x-text="task.start_time"></span></p>
+            <p x-show="task.end_time">End: <span x-text="task.end_time"></span></p>
+          </div>
+        </div>
+      </template>
+      <p x-show="filtered.length === 0 && !error" class="text-gray-500 text-sm">No tasks found for this period.</p>
+    </div>
+  </main>
+
+  <script type="module" src="/js/app.js"></script>
+  <script>
+    function tasksPage() {
+      return {
+        dateRange: "today",
+        statusFilter: "all",
+        tasks: [],
+        filtered: [],
+        error: null,
+
+        async init() {
+          await this.refresh();
+        },
+
+        async refresh() {
+          const { since, until } = this.dateParams();
+          let url = `/tasks/history?limit=200&since=${since}`;
+          if (until) url += `&until=${until}`;
+          const res = await api(url);
+          if (res.error) {
+            this.error = res.error;
+            return;
+          }
+          this.error = null;
+          this.tasks = (res.data.executions || []).map(t => ({ ...t, _expanded: false }));
+          this.applyFilter();
+        },
+
+        applyFilter() {
+          if (this.statusFilter === "all") {
+            this.filtered = this.tasks;
+          } else {
+            this.filtered = this.tasks.filter(t => t.status === this.statusFilter);
+          }
+        },
+
+        dateParams() {
+          const now = new Date();
+          let since, until;
+          if (this.dateRange === "today") {
+            since = startOfDay(now);
+          } else if (this.dateRange === "yesterday") {
+            const y = new Date(now);
+            y.setDate(y.getDate() - 1);
+            since = startOfDay(y);
+            until = endOfDay(y);
+          } else if (this.dateRange === "7d") {
+            const d = new Date(now);
+            d.setDate(d.getDate() - 7);
+            since = startOfDay(d);
+          } else {
+            const d = new Date(now);
+            d.setDate(d.getDate() - 30);
+            since = startOfDay(d);
+          }
+          return { since, until };
+        },
+
+        dotColor(status) {
+          if (status === "success") return "bg-status-ok";
+          if (status === "failure" || status === "timeout") return "bg-status-error";
+          return "bg-status-pending";
+        },
+
+        formatDuration(sec) {
+          if (!sec) return "";
+          if (sec < 60) return Math.round(sec) + "s";
+          return Math.round(sec / 60) + "m " + Math.round(sec % 60) + "s";
+        },
+
+        formatDateTime(ts) {
+          if (!ts) return "";
+          return new Date(ts).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+        },
+      };
+    }
+
+    function startOfDay(d) {
+      const c = new Date(d);
+      c.setHours(0, 0, 0, 0);
+      return c.toISOString();
+    }
+
+    function endOfDay(d) {
+      const c = new Date(d);
+      c.setHours(23, 59, 59, 999);
+      return c.toISOString();
+    }
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/src/tasks.html
+git commit -m "feat(bede-web): task execution history page"
+```
+
+---
+
+### Task 6: Memories Page (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/src/memories.html`
+
+- [ ] **Step 1: Create memories.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bede — Memories</title>
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body>
+  <load src="partials/nav.html" />
+
+  <main class="max-w-4xl mx-auto p-6" x-data="memoriesPage()" x-init="init()">
+    <h1 class="text-xl font-semibold mb-4">Memories</h1>
+
+    <div class="flex flex-wrap gap-3 mb-4">
+      <input
+        type="text"
+        x-model="search"
+        @input="applyFilter()"
+        placeholder="Search memories..."
+        class="bg-surface-card border border-surface-border rounded px-3 py-1 text-sm text-gray-200 w-64"
+      />
+      <select x-model="typeFilter" @change="applyFilter()" class="bg-surface-card border border-surface-border rounded px-3 py-1 text-sm text-gray-200">
+        <option value="all">All types</option>
+        <option value="fact">Fact</option>
+        <option value="preference">Preference</option>
+        <option value="correction">Correction</option>
+      </select>
+    </div>
+
+    <template x-if="error">
+      <div class="bg-surface-card border border-status-error rounded-lg p-4 text-status-error text-sm" x-text="error"></div>
+    </template>
+
+    <div class="space-y-2">
+      <template x-for="mem in filtered" :key="mem.id">
+        <div class="bg-surface-card border border-surface-border rounded-lg p-3">
+          <div class="flex items-start justify-between gap-3">
+            <p class="text-sm text-gray-200" x-text="mem.content"></p>
+            <span class="shrink-0 text-xs px-2 py-0.5 rounded" :class="typeBadge(mem.type)" x-text="mem.type"></span>
+          </div>
+          <div class="flex gap-4 mt-2 text-xs text-gray-500">
+            <span>Created: <span x-text="formatDate(mem.created_at)"></span></span>
+            <span x-show="mem.last_referenced_at">Last used: <span x-text="formatDate(mem.last_referenced_at)"></span></span>
+          </div>
+        </div>
+      </template>
+      <p x-show="filtered.length === 0 && !error" class="text-gray-500 text-sm">No memories found.</p>
+    </div>
+  </main>
+
+  <script type="module" src="/js/app.js"></script>
+  <script>
+    function memoriesPage() {
+      return {
+        memories: [],
+        filtered: [],
+        search: "",
+        typeFilter: "all",
+        error: null,
+
+        async init() {
+          const res = await api("/memories?limit=500");
+          if (res.error) {
+            this.error = res.error;
+            return;
+          }
+          this.memories = res.data.memories || [];
+          this.applyFilter();
+        },
+
+        applyFilter() {
+          let result = this.memories;
+          if (this.typeFilter !== "all") {
+            result = result.filter(m => m.type === this.typeFilter);
+          }
+          if (this.search.trim()) {
+            const q = this.search.toLowerCase();
+            result = result.filter(m => m.content.toLowerCase().includes(q));
+          }
+          this.filtered = result;
+        },
+
+        typeBadge(type) {
+          if (type === "fact") return "bg-blue-900/50 text-blue-300";
+          if (type === "preference") return "bg-purple-900/50 text-purple-300";
+          if (type === "correction") return "bg-amber-900/50 text-amber-300";
+          return "bg-gray-700 text-gray-300";
+        },
+
+        formatDate(ts) {
+          if (!ts) return "";
+          return new Date(ts).toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
+        },
+      };
+    }
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/src/memories.html
+git commit -m "feat(bede-web): memories browser page"
+```
+
+---
+
+### Task 7: Goals Page (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/src/goals.html`
+
+- [ ] **Step 1: Create goals.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bede — Goals</title>
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body>
+  <load src="partials/nav.html" />
+
+  <main class="max-w-4xl mx-auto p-6" x-data="goalsPage()" x-init="init()">
+    <h1 class="text-xl font-semibold mb-4">Goals</h1>
+
+    <div class="flex gap-3 mb-4">
+      <select x-model="statusFilter" @change="applyFilter()" class="bg-surface-card border border-surface-border rounded px-3 py-1 text-sm text-gray-200">
+        <option value="active">Active</option>
+        <option value="completed">Completed</option>
+        <option value="all">All</option>
+      </select>
+    </div>
+
+    <template x-if="error">
+      <div class="bg-surface-card border border-status-error rounded-lg p-4 text-status-error text-sm" x-text="error"></div>
+    </template>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <template x-for="goal in filtered" :key="goal.id">
+        <div class="bg-surface-card border rounded-lg p-4" :class="goalBorder(goal)">
+          <div class="flex items-start justify-between mb-2">
+            <h3 class="text-sm font-medium text-gray-100" x-text="goal.name"></h3>
+            <span class="shrink-0 text-xs px-2 py-0.5 rounded" :class="statusBadge(goal.status)" x-text="goal.status"></span>
+          </div>
+          <p x-show="goal.description" class="text-xs text-gray-400 mb-2" x-text="goal.description"></p>
+          <div class="flex gap-4 text-xs text-gray-500">
+            <span x-show="goal.deadline">Deadline: <span x-text="goal.deadline"></span></span>
+            <span>Updated: <span x-text="formatDate(goal.updated_at)"></span></span>
+          </div>
+          <p x-show="goal.measurable_indicators" class="text-xs text-gray-500 mt-1" x-text="goal.measurable_indicators"></p>
+        </div>
+      </template>
+      <p x-show="filtered.length === 0 && !error" class="text-gray-500 text-sm col-span-2">No goals found.</p>
+    </div>
+  </main>
+
+  <script type="module" src="/js/app.js"></script>
+  <script>
+    function goalsPage() {
+      return {
+        goals: [],
+        filtered: [],
+        statusFilter: "active",
+        error: null,
+
+        async init() {
+          const res = await api("/goals");
+          if (res.error) {
+            this.error = res.error;
+            return;
+          }
+          this.goals = res.data.goals || [];
+          this.applyFilter();
+        },
+
+        applyFilter() {
+          if (this.statusFilter === "all") {
+            this.filtered = this.goals;
+          } else {
+            this.filtered = this.goals.filter(g => g.status === this.statusFilter);
+          }
+        },
+
+        goalBorder(goal) {
+          if (goal.status !== "active") return "border-surface-border";
+          const updated = new Date(goal.updated_at);
+          const daysSince = (Date.now() - updated.getTime()) / 86400000;
+          if (daysSince > 14) return "border-status-warn";
+          return "border-surface-border";
+        },
+
+        statusBadge(status) {
+          if (status === "active") return "bg-blue-900/50 text-blue-300";
+          if (status === "completed") return "bg-green-900/50 text-green-300";
+          return "bg-gray-700 text-gray-300";
+        },
+
+        formatDate(ts) {
+          if (!ts) return "";
+          return new Date(ts).toLocaleDateString([], { month: "short", day: "numeric" });
+        },
+      };
+    }
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/src/goals.html
+git commit -m "feat(bede-web): goals page"
+```
+
+---
+
+### Task 8: Conversations Page (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/src/conversations.html`
+
+- [ ] **Step 1: Create conversations.html**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bede — Conversations</title>
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body>
+  <load src="partials/nav.html" />
+
+  <main class="max-w-4xl mx-auto p-6" x-data="conversationsPage()" x-init="init()">
+    <h1 class="text-xl font-semibold mb-4">Conversations</h1>
+
+    <template x-if="error">
+      <div class="bg-surface-card border border-status-error rounded-lg p-4 text-status-error text-sm" x-text="error"></div>
+    </template>
+
+    <div class="space-y-2">
+      <template x-for="session in sessions" :key="session.session_id">
+        <div class="bg-surface-card border border-surface-border rounded-lg p-3">
+          <div class="flex items-center justify-between cursor-pointer" @click="toggle(session)">
+            <div class="flex items-center gap-3">
+              <span class="text-sm text-gray-200" x-text="formatDate(session.first_timestamp)"></span>
+              <span class="text-xs text-gray-500" x-text="session.message_count + ' messages'"></span>
+            </div>
+            <span class="text-xs text-gray-500 font-mono" x-text="session.session_id.slice(0, 8) + '…'"></span>
+          </div>
+          <div x-show="session._expanded" x-cloak class="mt-3 border-t border-surface-border pt-3">
+            <template x-if="session._loading">
+              <p class="text-xs text-gray-500">Loading…</p>
+            </template>
+            <div x-show="session._messages" class="space-y-3 max-h-96 overflow-y-auto text-sm">
+              <template x-for="(msg, idx) in session._messages || []" :key="idx">
+                <div class="border-l-2 pl-3" :class="msg.role === 'user' ? 'border-status-pending' : 'border-status-ok'">
+                  <p class="text-xs text-gray-500 mb-1" x-text="msg.role + ' · ' + formatTime(msg.timestamp)"></p>
+                  <div class="text-gray-300 prose prose-sm prose-invert max-w-none" x-html="renderMarkdown(msg.content)"></div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+      </template>
+      <p x-show="sessions.length === 0 && !error" class="text-gray-500 text-sm">No conversations found.</p>
+    </div>
+  </main>
+
+  <script type="module" src="/js/app.js"></script>
+  <script>
+    function conversationsPage() {
+      return {
+        sessions: [],
+        error: null,
+
+        async init() {
+          const res = await api("/conversations");
+          if (res.error) {
+            this.error = res.error;
+            return;
+          }
+          this.sessions = (res.data.sessions || [])
+            .sort((a, b) => (b.first_timestamp || "").localeCompare(a.first_timestamp || ""))
+            .map(s => ({ ...s, _expanded: false, _loading: false, _messages: null }));
+        },
+
+        async toggle(session) {
+          if (session._expanded) {
+            session._expanded = false;
+            return;
+          }
+          session._expanded = true;
+          if (session._messages) return;
+
+          session._loading = true;
+          const res = await api(`/conversations/${session.session_id}`);
+          session._loading = false;
+          if (res.error) {
+            session._messages = [{ role: "system", content: "Failed to load: " + res.error, timestamp: "" }];
+            return;
+          }
+          session._messages = (res.data.messages || []).filter(m => m.role && m.content);
+        },
+
+        formatDate(ts) {
+          if (!ts) return "Unknown date";
+          return new Date(ts).toLocaleDateString([], { weekday: "short", month: "short", day: "numeric" });
+        },
+
+        formatTime(ts) {
+          if (!ts) return "";
+          return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+        },
+      };
+    }
+  </script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Verify build succeeds**
+
+Run: `cd /Users/joeradford/dev/bede/bede-web && npm run build`
+Expected: `dist/` directory created with all 5 HTML files and bundled CSS/JS assets.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/src/conversations.html
+git commit -m "feat(bede-web): conversations page with expandable transcripts"
+```
+
+---
+
+### Task 9: nginx Configuration (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/nginx.conf`
+
+- [ ] **Step 1: Create nginx.conf**
+
+```nginx
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://bede-data:8001/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(js|css|png|ico|svg)$ {
+        expires 1h;
+        add_header Cache-Control "public, immutable";
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/nginx.conf
+git commit -m "feat(bede-web): nginx config with API proxy to bede-data"
+```
+
+---
+
+### Task 10: Dockerfile (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/bede-web/Dockerfile`
+
+- [ ] **Step 1: Create Dockerfile**
+
+```dockerfile
+FROM node:22-alpine AS build
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY vite.config.js tailwind.config.js postcss.config.js ./
+COPY src/ src/
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD wget -qO- http://localhost:80/ || exit 1
+```
+
+- [ ] **Step 2: Build and verify locally**
+
+Run: `cd /Users/joeradford/dev/bede && docker build -t bede-web:test bede-web/`
+Expected: Image builds successfully through both stages.
+
+Run: `docker run --rm -p 8080:80 bede-web:test &` then `curl -s http://localhost:8080/ | head -5`
+Expected: HTML content of the dashboard page. Then kill the container.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add bede-web/Dockerfile
+git commit -m "feat(bede-web): multi-stage Dockerfile (node build, nginx serve)"
+```
+
+---
+
+### Task 11: CI/CD Workflow (bede repo)
+
+**Files:**
+- Create: `/Users/joeradford/dev/bede/.github/workflows/bede-web-ci.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+```yaml
+name: bede-web CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "bede-web/**"
+  push:
+    branches: [main]
+    paths:
+      - "bede-web/**"
+
+defaults:
+  run:
+    working-directory: bede-web
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+          cache-dependency-path: bede-web/package-lock.json
+      - run: npm ci
+      - run: npm run build
+
+  build-push:
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./bede-web
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/josephradford/bede-web:latest
+            ghcr.io/josephradford/bede-web:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add .github/workflows/bede-web-ci.yml
+git commit -m "ci(bede-web): add build and push workflow"
+```
+
+---
+
+### Task 12: Update bede Makefile (bede repo)
+
+**Files:**
+- Modify: `/Users/joeradford/dev/bede/Makefile`
+
+- [ ] **Step 1: Add test-web target**
+
+Append to the Makefile:
+
+```makefile
+test-web:
+	cd bede-web && npm run build
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd /Users/joeradford/dev/bede && make test-web`
+Expected: Vite build completes successfully.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joeradford/dev/bede
+git add Makefile
+git commit -m "chore: add test-web Makefile target"
+```
+
+---
+
+### Task 13: Create PR in bede repo
+
+**Files:** None (git operations only)
+
+- [ ] **Step 1: Push and create PR**
+
+```bash
+cd /Users/joeradford/dev/bede
+git push -u origin HEAD
+gh pr create --title "feat: add bede-web dashboard and data browser" --body "$(cat <<'EOF'
+## Summary
+- Add bede-web: a static web UI served by nginx, built with Vite + Tailwind + Alpine.js
+- Dashboard page: data freshness, task status, storage, today's schedule (2×2 grid, auto-refresh)
+- Content pages: tasks (date/status filters), memories (search/type filter), goals (status filter), conversations (expandable transcripts)
+- Multi-stage Dockerfile: node build → nginx:alpine serve
+- nginx proxies /api/* to bede-data (same-origin, no CORS needed)
+- GitHub Actions CI: build verification on PR, push GHCR image on merge
+- Prerequisite: added since/until date filters to bede-data task history endpoint
+
+## Test plan
+- [ ] `npm run build` succeeds in bede-web/
+- [ ] Docker image builds: `docker build -t test bede-web/`
+- [ ] All bede-data tests pass: `cd bede-data && uv run pytest tests/ -v`
+- [ ] CI builds successfully on this PR
+- [ ] After merge: GHCR image published, set visibility to public
+- [ ] After deploy: pages load, API calls return data, dashboard auto-refreshes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Merge the PR**
+
+Wait for CI to pass, then merge. Wait for the GHCR image build to complete before deploying.
+
+- [ ] **Step 3: Set GHCR package visibility to public**
+
+Navigate to: `https://github.com/users/josephradford/packages/container/bede-web/settings`
+→ Danger Zone → Change visibility → Public
+
+---
+
+### Task 14: Docker Compose Wiring (home-server-stack repo)
+
+**Files:**
+- Modify: `/Users/joeradford/dev/home-server-stack/docker-compose.ai.yml`
+
+- [ ] **Step 1: Add bede-web service**
+
+Add the following service block after `bede-data-mcp` and before `bede-workspace-mcp`:
+
+```yaml
+  bede-web:
+    image: ghcr.io/josephradford/bede-web:latest
+    container_name: bede-web
+    restart: unless-stopped
+    networks:
+      - homeserver
+    depends_on:
+      bede-data:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:80/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.bede-web.rule=Host(`bede.${DOMAIN}`)"
+      - "traefik.http.routers.bede-web.entrypoints=websecure"
+      - "traefik.http.routers.bede-web.tls=true"
+      - "traefik.http.routers.bede-web.middlewares=admin-secure@docker"
+      - "traefik.http.routers.bede-web.service=bede-web"
+      - "traefik.http.services.bede-web.loadbalancer.server.port=80"
+```
+
+- [ ] **Step 2: Validate compose config**
+
+Run: `cd /Users/joeradford/dev/home-server-stack && make validate`
+Expected: PASS — config is valid.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joeradford/dev/home-server-stack
+git add docker-compose.ai.yml
+git commit -m "feat: add bede-web to docker compose"
+```
+
+---
+
+### Task 15: Makefile — Add bede-web to bede-pull (home-server-stack repo)
+
+**Files:**
+- Modify: `/Users/joeradford/dev/home-server-stack/Makefile`
+
+- [ ] **Step 1: Add bede-web image to bede-pull target**
+
+Add after the existing `bede-workspace-mcp` pull line (around line 365):
+
+```makefile
+	@docker pull ghcr.io/josephradford/bede-web:latest
+```
+
+The full target should read:
+
+```makefile
+bede-pull: env-check
+	@echo "Pulling Bede images..."
+	@docker pull ghcr.io/josephradford/bede-data:latest
+	@docker pull ghcr.io/josephradford/bede-data-mcp:latest
+	@docker pull ghcr.io/josephradford/bede-core:latest
+	@docker pull ghcr.io/josephradford/bede-workspace-mcp:latest
+	@docker pull ghcr.io/josephradford/bede-web:latest
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/joeradford/dev/home-server-stack
+git add Makefile
+git commit -m "chore: add bede-web to bede-pull target"
+```
+
+---
+
+### Task 16: Homepage Dashboard (home-server-stack repo)
+
+**Files:**
+- Modify: `/Users/joeradford/dev/home-server-stack/config/homepage/services-template.yaml`
+
+- [ ] **Step 1: Add bede-web to AI Services section**
+
+Add after the Bede Workspace MCP entry (around line 275):
+
+```yaml
+      - Bede Web:
+          icon: mdi-monitor-dashboard
+          href: https://bede.{{HOMEPAGE_VAR_DOMAIN}}
+          description: Bede operational dashboard
+          container: bede-web
+          server: my-docker
+          showStats: true
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/joeradford/dev/home-server-stack
+git add config/homepage/services-template.yaml
+git commit -m "feat: add bede-web to homepage dashboard"
+```
+
+---
+
+### Task 17: Update SERVICES.md (home-server-stack repo)
+
+**Files:**
+- Modify: `/Users/joeradford/dev/home-server-stack/SERVICES.md`
+
+- [ ] **Step 1: Add bede-web service documentation**
+
+Add after the `bede-workspace-mcp` entry in the AI Services section:
+
+```markdown
+#### bede-web
+- **Purpose:** Read-only operational dashboard and data browser for Bede — displays data freshness, task status, storage usage, schedule, memories, goals, and conversation history
+- **Access:** https://bede.${DOMAIN} (admin-secure middleware — IP whitelist + security headers)
+- **Image:** `ghcr.io/josephradford/bede-web:latest`
+- **Depends on:** bede-data (HTTP API proxied via nginx)
+```
+
+- [ ] **Step 2: Add to the routing table**
+
+Add a row:
+
+```markdown
+| bede-web | https://bede.${DOMAIN} | N/A |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/joeradford/dev/home-server-stack
+git add SERVICES.md
+git commit -m "docs: add bede-web to SERVICES.md"
+```
+
+---
+
+### Task 18: Validate and Create PR (home-server-stack repo)
+
+**Files:** None (validation and git operations only)
+
+- [ ] **Step 1: Run full validation**
+
+Run: `cd /Users/joeradford/dev/home-server-stack && make validate`
+Expected: PASS.
+
+- [ ] **Step 2: Push and create PR**
+
+```bash
+cd /Users/joeradford/dev/home-server-stack
+git push -u origin HEAD
+gh pr create --title "feat: wire bede-web into docker compose" --body "$(cat <<'EOF'
+## Summary
+- Add bede-web service to docker-compose.ai.yml with Traefik labels (bede.DOMAIN, admin-secure)
+- Add bede-web to bede-pull Makefile target
+- Add to homepage dashboard with mdi-monitor-dashboard icon
+- Document in SERVICES.md
+
+## Context
+Companion to josephradford/bede PR adding the bede-web static dashboard. The image is built with Vite (Tailwind + Alpine.js) and served by nginx, which also proxies /api/* to bede-data. After both PRs are merged and the GHCR image is built, deploy with `make bede-pull && make bede-restart`.
+
+## Test plan
+- [ ] `make validate` passes
+- [ ] After deploy: `make bede-status` shows bede-web healthy
+- [ ] https://bede.DOMAIN loads the dashboard (from VPN)
+- [ ] Dashboard cards populate with data from bede-data API
+- [ ] All content pages accessible and functional
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Post-Deployment Verification
+
+After both PRs are merged, the GHCR image is built, and the server is updated (`make bede-pull && make bede-restart`):
+
+1. **Container health:** `make bede-status` — bede-web should show healthy.
+2. **Dashboard loads:** Open `https://bede.${DOMAIN}` from VPN — should show the 2×2 card grid with live data.
+3. **API proxy works:** Check browser devtools network tab — `/api/freshness`, `/api/tasks/history`, `/api/storage`, `/api/config/schedules` all return 200 with JSON.
+4. **Content pages:** Navigate to Tasks, Memories, Goals, Conversations — each should load and display data.
+5. **Auto-refresh:** Wait 60 seconds on the dashboard — "Last updated" timestamp should advance.
+6. **Mobile:** Access from phone over VPN — layout should stack to single column.
+7. **GHCR visibility:** If `docker pull` fails with 403, set the package to public at `https://github.com/users/josephradford/packages/container/bede-web/settings`.


### PR DESCRIPTION
## Summary

- Remove mosquitto container — owntracks-recorder supports `OTR_PORT=0` to disable MQTT entirely
- Switch owntracks-recorder to HTTP-only mode (`OTR_PORT=0`, `OTR_HTTPHOST=0.0.0.0`)
- Remove dedicated `location` network (only needs `homeserver` for traefik)
- Remove mosquitto config file added in #185

Verified on server: recorder starts, accepts HTTP POSTs to `/pub`, and stores locations without MQTT.

## Test plan

- [x] `make validate` passes
- [x] Tested HTTP-only mode on server (container starts, `/pub` accepts POSTs)
- [ ] Deploy and verify owntracks stays healthy
- [ ] Verify location tracking from iPhone still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)