### PR TITLE
feat: wire bede-web into docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,7 @@ bede-pull: env-check
 	@docker pull ghcr.io/josephradford/bede-data-mcp:latest
 	@docker pull ghcr.io/josephradford/bede-core:latest
 	@docker pull ghcr.io/josephradford/bede-workspace-mcp:latest
+	@docker pull ghcr.io/josephradford/bede-web:latest
 	@echo "✓ Bede images pulled"
 
 bede-start: env-check

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -130,6 +130,12 @@ Currently deployed and active services.
 - **Image:** `ghcr.io/josephradford/bede-workspace-mcp:latest`
 - **Depends on:** Google OAuth credentials in `.env`
 
+#### bede-web
+- **Purpose:** Read-only operational dashboard and data browser for Bede — displays data freshness, task status, storage usage, schedule, memories, goals, and conversation history
+- **Access:** https://bede.${DOMAIN} (admin-secure middleware — IP whitelist + security headers)
+- **Image:** `ghcr.io/josephradford/bede-web:latest`
+- **Depends on:** bede-data (HTTP API proxied via nginx)
+
 ### Location Services
 
 #### owntracks-recorder
@@ -168,6 +174,7 @@ Currently deployed and active services.
 | bede-data | https://data.${DOMAIN} | N/A |
 | bede-data-mcp | Internal only | N/A |
 | bede-workspace-mcp | https://mcp.${DOMAIN} (OAuth only) | N/A |
+| bede-web | https://bede.${DOMAIN} | N/A |
 | owntracks-recorder | https://owntracks.${DOMAIN} | N/A |
 | hae-server | https://hae.${DOMAIN} | N/A |
 | hae-influxdb | https://influxdb.${DOMAIN} | N/A |

--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -273,6 +273,13 @@
           container: bede-workspace-mcp
           server: my-docker
           showStats: true
+      - Bede Web:
+          icon: mdi-monitor-dashboard
+          href: https://bede.{{HOMEPAGE_VAR_DOMAIN}}
+          description: Bede operational dashboard
+          container: bede-web
+          server: my-docker
+          showStats: true
 
   # Location Services - Location tracking
   - Location:

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -49,6 +49,29 @@ services:
       timeout: 5s
       retries: 3
 
+  bede-web:
+    image: ghcr.io/josephradford/bede-web:latest
+    container_name: bede-web
+    restart: unless-stopped
+    networks:
+      - homeserver
+    depends_on:
+      bede-data:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:80/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.bede-web.rule=Host(`bede.${DOMAIN}`)"
+      - "traefik.http.routers.bede-web.entrypoints=websecure"
+      - "traefik.http.routers.bede-web.tls=true"
+      - "traefik.http.routers.bede-web.middlewares=admin-secure@docker"
+      - "traefik.http.routers.bede-web.service=bede-web"
+      - "traefik.http.services.bede-web.loadbalancer.server.port=80"
+
   bede-workspace-mcp:
     image: ghcr.io/josephradford/bede-workspace-mcp:latest
     container_name: bede-workspace-mcp


### PR DESCRIPTION
## Summary
- Add bede-web service to docker-compose.ai.yml with Traefik labels (bede.DOMAIN, admin-secure)
- Add bede-web to bede-pull Makefile target
- Add to homepage dashboard with mdi-monitor-dashboard icon
- Document in SERVICES.md

## Context
Companion to josephradford/bede#68 adding the bede-web static dashboard. The image is built with Vite (Tailwind + Alpine.js) and served by nginx, which also proxies /api/* to bede-data. After both PRs are merged and the GHCR image is built, deploy with `make bede-pull && make bede-restart`.

## Test plan
- [ ] `make validate` passes
- [ ] After deploy: `make bede-status` shows bede-web healthy
- [ ] https://bede.DOMAIN loads the dashboard (from VPN)
- [ ] Dashboard cards populate with data from bede-data API
- [ ] All content pages accessible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)