### PR TITLE
fix: bede-web healthcheck use 127.0.0.1 instead of localhost

### DIFF
--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -59,7 +59,7 @@ services:
       bede-data:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:80/"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Nginx in the bede-web Alpine container only listens on IPv4 (`0.0.0.0:80`)
- Alpine's `wget` resolves `localhost` to `::1` (IPv6), causing connection refused
- Traefik sees the unhealthy container and returns 404 for all requests
- Fix: use `127.0.0.1` explicitly in the healthcheck

## Test plan
- [x] Verified on server — bede-web now healthy and serving at `bede.${DOMAIN}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)