### PR TITLE
feat: wire bede-browser-mcp into docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,6 +364,7 @@ bede-pull: env-check
 	@docker pull ghcr.io/josephradford/bede-core:latest
 	@docker pull ghcr.io/josephradford/bede-workspace-mcp:latest
 	@docker pull ghcr.io/josephradford/bede-web:latest
+	@docker pull mcr.microsoft.com/playwright/mcp:latest
 	@echo "✓ Bede images pulled"
 
 bede-start: env-check

--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,7 @@ bede-pull: env-check
 	@docker pull ghcr.io/josephradford/bede-core:latest
 	@docker pull ghcr.io/josephradford/bede-workspace-mcp:latest
 	@docker pull ghcr.io/josephradford/bede-web:latest
-	@docker pull mcr.microsoft.com/playwright/mcp:latest
+	@docker pull mcr.microsoft.com/playwright/mcp:v0.0.74
 	@echo "✓ Bede images pulled"
 
 bede-start: env-check

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -131,6 +131,13 @@ Currently deployed and active services.
 - **Image:** `ghcr.io/josephradford/bede-web:latest`
 - **Depends on:** bede-data (HTTP API proxied via nginx)
 
+#### bede-browser-mcp
+- **Purpose:** Headless Chromium browser access for bede-core via MCP — enables web browsing, screenshot capture, and page interaction
+- **Access:** Internal only (no Traefik routing) — bede-core connects via `http://bede-browser-mcp:8004/mcp`
+- **Image:** `mcr.microsoft.com/playwright/mcp:latest`
+- **Port:** 8004
+- **Depends on:** None (standalone sidecar)
+
 ### Location Services
 
 #### owntracks-recorder
@@ -158,6 +165,7 @@ Currently deployed and active services.
 | bede-data-mcp | Internal only | N/A |
 | bede-workspace-mcp | https://mcp.${DOMAIN} (OAuth only) | N/A |
 | bede-web | https://bede.${DOMAIN} | N/A |
+| bede-browser-mcp | Internal only | N/A |
 | owntracks-recorder | https://owntracks.${DOMAIN} | N/A |
 
 ---

--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -281,6 +281,13 @@
           server: my-docker
           showStats: true
 
+      - Bede Browser MCP:
+          icon: mdi-web
+          description: Headless browser access for Bede (internal MCP)
+          container: bede-browser-mcp
+          server: my-docker
+          showStats: true
+
   # Location Services - Location tracking
   - Location:
       - OwnTracks:

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -104,6 +104,19 @@ services:
       - "traefik.http.routers.workspace-mcp.service=workspace-mcp"
       - "traefik.http.services.workspace-mcp.loadbalancer.server.port=8003"
 
+  bede-browser-mcp:
+    image: mcr.microsoft.com/playwright/mcp:latest
+    container_name: bede-browser-mcp
+    restart: unless-stopped
+    command: ["--headless", "--port", "8004", "--host", "0.0.0.0", "--no-sandbox"]
+    networks:
+      - homeserver
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:8004/mcp').then(r => process.exit(r.status === 400 ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
   bede-core:
     image: ghcr.io/josephradford/bede-core:latest
     container_name: bede-core
@@ -135,6 +148,8 @@ services:
       bede-data-mcp:
         condition: service_healthy
       bede-workspace-mcp:
+        condition: service_healthy
+      bede-browser-mcp:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -105,7 +105,7 @@ services:
       - "traefik.http.services.workspace-mcp.loadbalancer.server.port=8003"
 
   bede-browser-mcp:
-    image: mcr.microsoft.com/playwright/mcp:latest
+    image: mcr.microsoft.com/playwright/mcp:v0.0.74
     container_name: bede-browser-mcp
     restart: unless-stopped
     command: ["--headless", "--port", "8004", "--host", "0.0.0.0", "--no-sandbox"]


### PR DESCRIPTION
## Summary
- Add bede-browser-mcp service to docker-compose.ai.yml using official `mcr.microsoft.com/playwright/mcp` image
- Runs headless Chromium on port 8004 with `--no-sandbox` for Docker compatibility
- Add as dependency of bede-core (service_healthy condition)
- Add to `bede-pull` Makefile target
- Add to homepage dashboard (AI Services section)
- Document in SERVICES.md with quick reference table entry

## Context
Companion to [josephradford/bede#71](https://github.com/josephradford/bede/pull/71) which adds the browser MCP entry to bede-core's mcp.json. Uses Microsoft's official Playwright MCP image instead of a custom Dockerfile — simpler and auto-updated.

After both PRs are merged, deploy with `make bede-pull && make bede-restart`.

## Test plan
- [x] `make validate` passes
- [ ] After deploy: `make bede-status` shows bede-browser-mcp healthy
- [ ] bede-core can discover and use browser MCP tools
- [ ] Homepage shows bede-browser-mcp container status

🤖 Generated with [Claude Code](https://claude.com/claude-code)