### PR TITLE
fix: add --allowed-hosts to browser-mcp for Docker network access

### DIFF
--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -108,7 +108,7 @@ services:
     image: mcr.microsoft.com/playwright/mcp:v0.0.74
     container_name: bede-browser-mcp
     restart: unless-stopped
-    command: ["--headless", "--port", "8004", "--host", "0.0.0.0", "--no-sandbox"]
+    command: ["--headless", "--port", "8004", "--host", "0.0.0.0", "--no-sandbox", "--allowed-hosts", "*"]
     networks:
       - homeserver
     healthcheck:


### PR DESCRIPTION
## Summary
- Add `--allowed-hosts *` to bede-browser-mcp command args
- Without this, the MCP server rejects connections from bede-core with 403 because it defaults to only accepting connections from its bound host (localhost), but Docker containers connect via the `bede-browser-mcp` hostname

## Test plan
- [x] Verified 403 without the flag (bede-core can't discover browser tools)
- [ ] After deploy: bede-core should see browser MCP tools
- [ ] Safe: container is internal-only on Docker network, no Traefik exposure

🤖 Generated with [Claude Code](https://claude.com/claude-code)