### PR TITLE
feat: pass AIR_QUALITY_SITE_ID to bede-data container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,6 +179,11 @@ GOOGLE_CALENDAR_ICAL_URL=https://calendar.google.com/calendar/ical/your_calendar
 # Examples: "parramatta", "sydney", "melbourne", "brisbane"
 BOM_LOCATION=parramatta
 
+# NSW Air Quality — monitoring site ID for air quality readings
+# Find site IDs via https://data.airquality.nsw.gov.au/api/Data/get_SiteDetails
+# 919 = Parramatta North, 1148 = Prospect
+AIR_QUALITY_SITE_ID=919
+
 # Transport NSW — real-time public transport departures
 # Get your API key from: https://opendata.transport.nsw.gov.au/
 TRANSPORT_NSW_API_KEY=your_api_key_here

--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -10,6 +10,7 @@ services:
       - OWNTRACKS_URL=http://owntracks-recorder:8083
       - OWNTRACKS_USER=${OWNTRACKS_USER}
       - OWNTRACKS_DEVICE=${OWNTRACKS_DEVICE}
+      - AIR_QUALITY_SITE_ID=${AIR_QUALITY_SITE_ID}
     volumes:
       - ./data/bede/sqlite:/data/sqlite
     networks:


### PR DESCRIPTION
## Summary
- Add `AIR_QUALITY_SITE_ID` env var passthrough in `docker-compose.ai.yml` for bede-data
- Document the setting in `.env.example` with site ID lookup reference
- Companion to [bede#72](https://github.com/josephradford/bede/pull/72) which fixes the air quality MCP endpoint

## Test plan
- [x] `make validate` passes
- [ ] Add `AIR_QUALITY_SITE_ID=919` to server `.env`
- [ ] Deploy bede-data + restart, verify `get_air_quality` returns readings

🤖 Generated with [Claude Code](https://claude.com/claude-code)