### PR TITLE
Fix transport departures: realtime times, cancelled filtering, data status

### DIFF
--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -57,6 +57,8 @@
             - field: departures.1.time
               label: Departs
               format: relativeDate
+            - field: data_status
+              label: Data
 
     - "{{HOMEPAGE_VAR_TRANSPORT_STOP_2_NAME}}":
         icon: {{HOMEPAGE_VAR_TRANSPORT_STOP_2_ICON}}
@@ -72,6 +74,8 @@
             - field: departures.1.time
               label: Following
               format: relativeDate
+            - field: data_status
+              label: Data
 
 - "{{HOMEPAGE_VAR_TRANSPORT_SECTION_2}}":
     - "{{HOMEPAGE_VAR_TRANSPORT_STOP_3_NAME}}":
@@ -92,6 +96,8 @@
             - field: departures.1.time
               label: Departs
               format: relativeDate
+            - field: data_status
+              label: Data
 
     - "{{HOMEPAGE_VAR_TRANSPORT_STOP_4_NAME}}":
         icon: {{HOMEPAGE_VAR_TRANSPORT_STOP_4_ICON}}
@@ -107,6 +113,8 @@
             - field: departures.1.time
               label: Following
               format: relativeDate
+            - field: data_status
+              label: Data
 
     - Transport NSW:
         icon: mdi-bus-multiple

--- a/homepage-api/app.py
+++ b/homepage-api/app.py
@@ -289,10 +289,14 @@ def transport_departures(stop_id):
 
         departures = []
         stop_events = data.get('stopEvents', [])
+        has_realtime = False
 
         for event in stop_events:
             if len(departures) >= limit:
                 break
+
+            if event.get('isCancelled'):
+                continue
 
             transportation = event.get('transportation', {})
             destination_name = transportation.get('destination', {}).get('name', '')
@@ -304,12 +308,17 @@ def transport_departures(stop_id):
                 continue
 
             location = event.get('location', {})
+            is_realtime = event.get('isRealtimeControlled', False)
 
             delay_minutes = 0
-            if event.get('isRealtimeControlled'):
+            departure_time = event.get('departureTimePlanned')
+            if is_realtime:
+                has_realtime = True
+                estimated_str = event.get('departureTimeEstimated')
+                if estimated_str:
+                    departure_time = estimated_str
                 try:
                     planned_str = event.get('departureTimePlanned')
-                    estimated_str = event.get('departureTimeEstimated')
                     if planned_str and estimated_str:
                         planned = datetime.fromisoformat(planned_str.replace('Z', '+00:00'))
                         estimated = datetime.fromisoformat(estimated_str.replace('Z', '+00:00'))
@@ -318,17 +327,18 @@ def transport_departures(stop_id):
                     delay_minutes = 0
 
             departures.append({
-                'time': event.get('departureTimePlanned'),
+                'time': departure_time,
                 'destination': destination_name,
                 'line': route_number,
                 'platform': location.get('properties', {}).get('platformName'),
-                'realtime': event.get('isRealtimeControlled', False),
+                'realtime': is_realtime,
                 'delay_minutes': delay_minutes
             })
 
         return jsonify({
             'stopId': stop_id,
             'departures': departures,
+            'data_status': 'Live' if has_realtime else 'Scheduled',
             'updated': datetime.now().isoformat()
         })
 


### PR DESCRIPTION
## Summary
- Use `departureTimeEstimated` from Transport NSW API when real-time data is available, instead of always showing `departureTimePlanned` (fixes incorrect tram departure times)
- Filter out cancelled services (`isCancelled`) so they no longer appear in the departure list
- Add `data_status` field ("Live" / "Scheduled") to the API response and display it in all 4 transport stop widgets

## Post-deploy
After deploying, re-run `./scripts/homepage/configure-homepage.sh` on the server (answer `y` to overwrite) to:
- Apply the updated widget template with the new Data status field
- Remove the stale Mosquitto card from the Location section

## Test plan
- [ ] `make validate` passes
- [ ] Deploy to server, rebuild homepage-api
- [ ] Verify tram departures show correct real-time estimated times
- [ ] Verify cancelled buses no longer appear in departure list
- [ ] Verify "Live" / "Scheduled" label appears on each transport widget
- [ ] Re-run configure-homepage.sh and verify Mosquitto card is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)