### PR TITLE
Fix homepage config script breaking on .env values with spaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,28 +192,29 @@ TRANSPORT_NSW_API_KEY=your_api_key_here
 # Each stop has an ID, display name, icon, and filter query string.
 # Find stop IDs at https://transportnsw.info/ or via the TfNSW stop finder API.
 # Filter is a URL query param: "destination=<substring>" or "routes=600,601"
-TRANSPORT_SECTION_1=Outbound
-TRANSPORT_SECTION_2=Inbound
+# Quote values that contain spaces.
+TRANSPORT_SECTION_1="Outbound"
+TRANSPORT_SECTION_2="Inbound"
 
 # Section 1 stops
 TRANSPORT_STOP_1_ID=12345678
-TRANSPORT_STOP_1_NAME=Bus Stop A
+TRANSPORT_STOP_1_NAME="Bus Stop A"
 TRANSPORT_STOP_1_ICON=mdi-bus
 TRANSPORT_STOP_1_FILTER=destination=city
 
 TRANSPORT_STOP_2_ID=12345679
-TRANSPORT_STOP_2_NAME=Tram Stop A
+TRANSPORT_STOP_2_NAME="Tram Stop A"
 TRANSPORT_STOP_2_ICON=mdi-tram
 TRANSPORT_STOP_2_FILTER=destination=terminus
 
 # Section 2 stops
 TRANSPORT_STOP_3_ID=12345680
-TRANSPORT_STOP_3_NAME=Bus Stop B
+TRANSPORT_STOP_3_NAME="Bus Stop B"
 TRANSPORT_STOP_3_ICON=mdi-bus
 TRANSPORT_STOP_3_FILTER=routes=100,101,102
 
 TRANSPORT_STOP_4_ID=12345681
-TRANSPORT_STOP_4_NAME=Tram Stop B
+TRANSPORT_STOP_4_NAME="Tram Stop B"
 TRANSPORT_STOP_4_ICON=mdi-tram
 TRANSPORT_STOP_4_FILTER=destination=suburb
 

--- a/scripts/homepage/configure-homepage.sh
+++ b/scripts/homepage/configure-homepage.sh
@@ -8,14 +8,6 @@ set -e
 echo "🏠 Configuring Homepage Dashboard"
 echo "=================================="
 
-# Load environment variables
-if [ ! -f .env ]; then
-    echo "❌ Error: .env file not found"
-    exit 1
-fi
-
-source .env
-
 # Ensure config directory exists
 CONFIG_DIR="data/homepage/config"
 TEMPLATE_DIR="config/homepage"


### PR DESCRIPTION
## Summary
- Remove unnecessary `source .env` from `configure-homepage.sh` — the script only copies template files and uses no env vars, but `source .env` breaks on unquoted values with spaces (e.g. `TRANSPORT_SECTION_1=To Parramatta`)
- Quote transport values in `.env.example` to set the right pattern

## Test plan
- [ ] `./scripts/homepage/configure-homepage.sh` runs without errors
- [ ] `make validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)