### PR TITLE
Per-departure realtime tracking indicators on transport widgets

### DIFF
--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -52,13 +52,25 @@
             - field: departures.0.time
               label: Departs
               format: relativeDate
+            - field: departures.0.realtime
+              label: Tracking
+              remap:
+                - value: true
+                  to: "● Live"
+                - value: false
+                  to: "○ Sched"
             - field: departures.1.line
               label: Following
             - field: departures.1.time
               label: Departs
               format: relativeDate
-            - field: data_status
-              label: Data
+            - field: departures.1.realtime
+              label: Tracking
+              remap:
+                - value: true
+                  to: "● Live"
+                - value: false
+                  to: "○ Sched"
 
     - "{{HOMEPAGE_VAR_TRANSPORT_STOP_2_NAME}}":
         icon: {{HOMEPAGE_VAR_TRANSPORT_STOP_2_ICON}}
@@ -71,11 +83,23 @@
             - field: departures.0.time
               label: Next
               format: relativeDate
+            - field: departures.0.realtime
+              label: Tracking
+              remap:
+                - value: true
+                  to: "● Live"
+                - value: false
+                  to: "○ Sched"
             - field: departures.1.time
               label: Following
               format: relativeDate
-            - field: data_status
-              label: Data
+            - field: departures.1.realtime
+              label: Tracking
+              remap:
+                - value: true
+                  to: "● Live"
+                - value: false
+                  to: "○ Sched"
 
 - "{{HOMEPAGE_VAR_TRANSPORT_SECTION_2}}":
     - "{{HOMEPAGE_VAR_TRANSPORT_STOP_3_NAME}}":
@@ -91,13 +115,25 @@
             - field: departures.0.time
               label: Departs
               format: relativeDate
+            - field: departures.0.realtime
+              label: Tracking
+              remap:
+                - value: true
+                  to: "● Live"
+                - value: false
+                  to: "○ Sched"
             - field: departures.1.line
               label: Following
             - field: departures.1.time
               label: Departs
               format: relativeDate
-            - field: data_status
-              label: Data
+            - field: departures.1.realtime
+              label: Tracking
+              remap:
+                - value: true
+                  to: "● Live"
+                - value: false
+                  to: "○ Sched"
 
     - "{{HOMEPAGE_VAR_TRANSPORT_STOP_4_NAME}}":
         icon: {{HOMEPAGE_VAR_TRANSPORT_STOP_4_ICON}}
@@ -113,8 +149,13 @@
             - field: departures.1.time
               label: Following
               format: relativeDate
-            - field: data_status
-              label: Data
+            - field: departures.1.realtime
+              label: Tracking
+              remap:
+                - value: true
+                  to: "● Live"
+                - value: false
+                  to: "○ Sched"
 
     - Transport NSW:
         icon: mdi-bus-multiple

--- a/homepage-api/app.py
+++ b/homepage-api/app.py
@@ -289,8 +289,6 @@ def transport_departures(stop_id):
 
         departures = []
         stop_events = data.get('stopEvents', [])
-        has_realtime = False
-
         for event in stop_events:
             if len(departures) >= limit:
                 break
@@ -313,7 +311,6 @@ def transport_departures(stop_id):
             delay_minutes = 0
             departure_time = event.get('departureTimePlanned')
             if is_realtime:
-                has_realtime = True
                 estimated_str = event.get('departureTimeEstimated')
                 if estimated_str:
                     departure_time = estimated_str
@@ -338,7 +335,6 @@ def transport_departures(stop_id):
         return jsonify({
             'stopId': stop_id,
             'departures': departures,
-            'data_status': 'Live' if has_realtime else 'Scheduled',
             'updated': datetime.now().isoformat()
         })
 


### PR DESCRIPTION
## Summary
- Replace top-level `data_status` field with per-departure `realtime` status using Homepage's `remap` feature
- Each departure now shows `● Live` or `○ Sched` next to its time
- Remove unused `has_realtime` / `data_status` from API response

## Test plan
- [ ] Transport widgets show `● Live` next to departures with real-time tracking
- [ ] Transport widgets show `○ Sched` next to departures without real-time data
- [ ] Each departure has its own independent tracking status

🤖 Generated with [Claude Code](https://claude.com/claude-code)