### PR TITLE
fix: switch bus cards to list display so all 6 fields render

### DIFF
--- a/config/homepage/services-template.yaml
+++ b/config/homepage/services-template.yaml
@@ -46,6 +46,7 @@
           type: customapi
           url: http://homepage-api:5000/api/transport/departures/{{HOMEPAGE_VAR_TRANSPORT_STOP_1_ID}}?{{HOMEPAGE_VAR_TRANSPORT_STOP_1_FILTER}}
           refreshInterval: 60000
+          display: list
           mappings:
             - field: departures.0.line
               label: Next
@@ -79,9 +80,12 @@
           type: customapi
           url: http://homepage-api:5000/api/transport/departures/{{HOMEPAGE_VAR_TRANSPORT_STOP_2_ID}}?{{HOMEPAGE_VAR_TRANSPORT_STOP_2_FILTER}}
           refreshInterval: 60000
+          display: list
           mappings:
-            - field: departures.0.time
+            - field: departures.0.line
               label: Next
+            - field: departures.0.time
+              label: Departs
               format: relativeDate
             - field: departures.0.realtime
               label: Tracking
@@ -90,8 +94,10 @@
                   to: "● Live"
                 - value: false
                   to: "○ Sched"
-            - field: departures.1.time
+            - field: departures.1.line
               label: Following
+            - field: departures.1.time
+              label: Departs
               format: relativeDate
             - field: departures.1.realtime
               label: Tracking
@@ -109,6 +115,7 @@
           type: customapi
           url: http://homepage-api:5000/api/transport/departures/{{HOMEPAGE_VAR_TRANSPORT_STOP_3_ID}}?{{HOMEPAGE_VAR_TRANSPORT_STOP_3_FILTER}}
           refreshInterval: 60000
+          display: list
           mappings:
             - field: departures.0.line
               label: Next
@@ -142,12 +149,24 @@
           type: customapi
           url: http://homepage-api:5000/api/transport/departures/{{HOMEPAGE_VAR_TRANSPORT_STOP_4_ID}}?{{HOMEPAGE_VAR_TRANSPORT_STOP_4_FILTER}}
           refreshInterval: 60000
+          display: list
           mappings:
-            - field: departures.0.time
+            - field: departures.0.line
               label: Next
+            - field: departures.0.time
+              label: Departs
               format: relativeDate
-            - field: departures.1.time
+            - field: departures.0.realtime
+              label: Tracking
+              remap:
+                - value: true
+                  to: "● Live"
+                - value: false
+                  to: "○ Sched"
+            - field: departures.1.line
               label: Following
+            - field: departures.1.time
+              label: Departs
               format: relativeDate
             - field: departures.1.realtime
               label: Tracking


### PR DESCRIPTION
## Summary
- Adds `display: list` to all 4 transport stop customapi widgets, bypassing the block view's hard-coded 4-field limit (`mappings.slice(0, 4)`)
- Adds missing route number (`line`) and tracking (`realtime` remap) fields to stops 2 and 4, making all stops consistent with the full 6-field layout: next route, departs, tracking, following route, departs, tracking

## Test plan
- [ ] Deploy to server and verify all 4 bus cards show 6 fields each in list view
- [ ] Confirm `relativeDate` formatting and `remap` values render correctly in list display mode
- [ ] Check card layout doesn't break on mobile/narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)