### PR TITLE
feat: mount claude sessions into bede-data for conversations page

### DIFF
--- a/docker-compose.ai.yml
+++ b/docker-compose.ai.yml
@@ -13,6 +13,7 @@ services:
       - AIR_QUALITY_SITE_ID=${AIR_QUALITY_SITE_ID}
     volumes:
       - ./data/bede/sqlite:/data/sqlite
+      - ./data/bede/claude-projects/-app:/data/bede/claude-sessions:ro
     networks:
       - homeserver
       - location


### PR DESCRIPTION
## Summary
- Add read-only volume mount from `./data/bede/claude-projects/-app` into bede-data at `/data/bede/claude-sessions`
- This gives the conversations API access to the Claude CLI session files that bede-core generates

## Context
The bede-web conversations page is empty because the session JSONL files live in bede-core's volume (`claude-projects/-app/`) but bede-data's conversations API reads from `/data/bede/claude-sessions` which was never mounted. Companion to bede repo PR #80 that fixes the API to read flat `.jsonl` files.

## Test plan
- [ ] `make validate` passes
- [ ] After deploy: `curl http://bede-data:8001/api/conversations` returns session list
- [ ] bede-web conversations page shows conversation sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)